### PR TITLE
retrieve array by subset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ thiserror = "2.0.18"
 zarrs = { version = "0.23", features = ["async", "ndarray"] }
 zarrs_object_store = { version = "0.6.2" }
 
+[dev-dependencies]
+# `auto-initialize` lets `cargo test` start a Python interpreter for `Python::attach`.
+pyo3 = { version = "0.29", features = ["auto-initialize"] }
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -1,35 +1,29 @@
 # zarrista
 
-A small, prototypical zarrita-like Python Zarr implementation on top of
-[zarrs](https://github.com/LDeakin/zarrs).
+A low-level Zarr API for Python, inspired by [zarrita.js], powered from Rust by [Zarrs].
 
-> **Status:** early prototype. This is currently a hello-world pyo3 scaffold;
-> the `zarrs` bindings are not implemented yet.
+[zarrita.js]: https://zarrita.dev/
+[Zarrs]: https://zarrs.dev/
+
+This has been _minimally_ vibe-coded (Claude still writes bad Rust code in my opinion).
 
 ## Development
 
-Requires a Rust toolchain and Python 3.11+. We use [uv](https://docs.astral.sh/uv/)
-and [maturin](https://www.maturin.rs/).
+Requires a Rust toolchain and Python 3.11+. We use
+[uv](https://docs.astral.sh/uv/) and [maturin](https://www.maturin.rs/).
 
 ```bash
 # Create a dev environment and install the dev dependencies
-uv sync
+uv sync --no-install-package zarrista
 
 # Build the Rust extension and install it into the environment (debug build)
-uv run maturin develop
+uv run --no-project maturin develop --uv
+
+# Or, in release mode:
+uv run --no-project maturin develop --uv --release
 
 # Run the tests
-uv run pytest
+uv run --no-project pytest
 ```
 
-Quick check that it imports:
-
-```bash
-uv run python -c "import zarrista; print(zarrista.__version__, zarrista.hello())"
-```
-
-## Layout
-
-- `src/lib.rs` — the Rust extension module, compiled to `zarrista._zarrista`.
-- `python/zarrista/` — the pure-Python package that re-exports the compiled module.
-- `tests/` — pytest smoke tests.
+The `--no-project` is annoying but unavoidable in our current setup. Otherwise `uv` will try to build the rust library _in release mode, as a dependency of the project_ before reaching `uv sync` or `uv run`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "obstore>=0.10.1",
     "pytest>=8.0",
     "ruff>=0.6",
+    "zarr>=3",
 ]
 
 [tool.ruff]

--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -1,3 +1,4 @@
+from types import EllipsisType
 from typing import Any
 
 from obstore.store import ObjectStore
@@ -7,6 +8,16 @@ from ._codec import CodecChain
 from ._data import Data
 from ._dtype import DataType
 from ._store import FilesystemStore, MemoryStore
+
+_AxisSelector = int | slice | EllipsisType
+Selection = _AxisSelector | tuple[_AxisSelector, ...]
+"""A numpy-style basic-indexing selection: what you would write inside `[]`.
+
+Supports integers, step-1 slices, `Ellipsis`, and tuples of those (with fewer
+entries than `ndim` implying full trailing axes). Negative indices and slice
+bounds are normalized. `step != 1`, `None`/newaxis, boolean, and fancy/array
+indexing are not supported.
+"""
 
 class Array:
     """A read-only Zarr array."""
@@ -38,11 +49,22 @@ class Array:
     @property
     def path(self) -> str:
         """The array's path in the store."""
+    def retrieve_array_subset(self, selection: Selection) -> Data:
+        """Read and decode an array region selected with numpy-style basic indexing.
+
+        The result is ndim-preserving (consistent with a zarrs `ArraySubset`): an
+        integer selects a length-1 range and that axis is retained.
+        """
     def retrieve_chunk(self, chunk_indices: list[int]) -> Data:
         """Read and decode the chunk at the given chunk grid indices."""
     @property
     def shape(self) -> list[int]:
         """The array shape."""
+    def __getitem__(self, selection: Selection) -> Data:
+        """Read a region with numpy-style basic indexing, e.g. `arr[0:10, :, 5]`.
+
+        Sugar for `retrieve_array_subset`.
+        """
     def __repr__(self) -> str: ...
 
 class AsyncArray:
@@ -75,9 +97,20 @@ class AsyncArray:
     @property
     def path(self) -> str:
         """The array's path in the store."""
+    async def retrieve_array_subset(self, selection: Selection) -> Data:
+        """Read and decode an array region selected with numpy-style basic indexing.
+
+        The result is ndim-preserving (consistent with a zarrs `ArraySubset`): an
+        integer selects a length-1 range and that axis is retained.
+        """
     async def retrieve_chunk(self, chunk_indices: list[int]) -> Data:
         """Read and decode the chunk at the given chunk grid indices."""
     @property
     def shape(self) -> list[int]:
         """The array shape."""
+    async def __getitem__(self, selection: Selection) -> Data:
+        """Read a region with numpy-style basic indexing: `await arr[0:10, :, 5]`.
+
+        Sugar for `retrieve_array_subset`.
+        """
     def __repr__(self) -> str: ...

--- a/python/zarrista/_data.pyi
+++ b/python/zarrista/_data.pyi
@@ -12,8 +12,8 @@ class Data(Buffer):
     """A decoded chunk of array data.
 
     Implements the Python buffer protocol (PEP 3118), so dtypes with a native
-    buffer representation can be read zero-copy via ``memoryview(data)`` or
-    ``np.asarray(data)``. Dtypes without one raise ``BufferError``.
+    buffer representation can be read zero-copy via `memoryview(data)` or
+    `np.asarray(data)`. Dtypes without one raise `BufferError`.
     """
 
     def __buffer__(self, flags: int) -> memoryview: ...

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -2,9 +2,10 @@
 
 use std::sync::Arc;
 
+use crate::array::selection::PySelectionInput;
 use crate::chunks::PyChunkGrid;
 use crate::codec::PyCodecChain;
-use crate::data::{DataInner, PyData};
+use crate::data::{for_each_dtype, DataInner, PyData};
 use crate::dtype::PyDataType;
 use crate::error::ZarristaError;
 use crate::node::PyNodePath;
@@ -107,6 +108,48 @@ impl PyAsyncArray {
         self.inner.path().as_str()
     }
 
+    /// Read a region of the array as `Data`, using numpy-style basic indexing.
+    fn retrieve_array_subset<'py>(
+        &self,
+        py: Python<'py>,
+        selection: PySelectionInput,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        use zarrs::array::data_type::*;
+
+        let inner = self.inner.clone();
+        let array_subset = selection.to_array_subset(inner.shape())?;
+
+        future_into_py(py, async move {
+            let dtype = inner.data_type();
+
+            macro_rules! arm {
+                ($dtype:ty, $variant:ident, $elem:ty) => {
+                    if dtype.is::<$dtype>() {
+                        let data = inner
+                            .async_retrieve_array_subset::<ArrayD<$elem>>(&array_subset)
+                            .await
+                            .map_err(ZarristaError::from)?;
+                        return Ok(PyData::from(DataInner::$variant(data)));
+                    }
+                };
+            }
+            for_each_dtype!(arm);
+
+            Err(PyNotImplementedError::new_err(format!(
+                "reading data type {dtype} is not supported yet"
+            )))
+        })
+    }
+
+    /// Read a region with numpy-style basic indexing, e.g. `await arr[0:10, :, 5]`.
+    fn __getitem__<'py>(
+        &self,
+        py: Python<'py>,
+        selection: PySelectionInput,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        self.retrieve_array_subset(py, selection)
+    }
+
     fn retrieve_chunk<'py>(
         &self,
         py: Python<'py>,
@@ -119,7 +162,7 @@ impl PyAsyncArray {
         future_into_py(py, async move {
             let dtype = inner.data_type();
 
-            macro_rules! retrieve {
+            macro_rules! arm {
                 ($dtype:ty, $variant:ident, $elem:ty) => {
                     if dtype.is::<$dtype>() {
                         let chunk = inner
@@ -130,19 +173,7 @@ impl PyAsyncArray {
                     }
                 };
             }
-
-            retrieve!(BoolDataType, Bool, bool);
-            retrieve!(Int8DataType, Int8, i8);
-            retrieve!(Int16DataType, Int16, i16);
-            retrieve!(Int32DataType, Int32, i32);
-            retrieve!(Int64DataType, Int64, i64);
-            retrieve!(UInt8DataType, Uint8, u8);
-            retrieve!(UInt16DataType, Uint16, u16);
-            retrieve!(UInt32DataType, Uint32, u32);
-            retrieve!(UInt64DataType, Uint64, u64);
-            retrieve!(Float16DataType, Float16, half::f16);
-            retrieve!(Float32DataType, Float32, f32);
-            retrieve!(Float64DataType, Float64, f64);
+            for_each_dtype!(arm);
 
             Err(PyNotImplementedError::new_err(format!(
                 "reading data type {dtype} is not supported yet"

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::array::selection::PySelectionInput;
+use crate::array::selection::PySelection;
 use crate::chunks::PyChunkGrid;
 use crate::codec::PyCodecChain;
 use crate::data::{for_each_dtype, DataInner, PyData};
@@ -112,7 +112,7 @@ impl PyAsyncArray {
     fn retrieve_array_subset<'py>(
         &self,
         py: Python<'py>,
-        selection: PySelectionInput,
+        selection: PySelection,
     ) -> PyResult<Bound<'py, PyAny>> {
         use zarrs::array::data_type::*;
 
@@ -145,7 +145,7 @@ impl PyAsyncArray {
     fn __getitem__<'py>(
         &self,
         py: Python<'py>,
-        selection: PySelectionInput,
+        selection: PySelection,
     ) -> PyResult<Bound<'py, PyAny>> {
         self.retrieve_array_subset(py, selection)
     }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -1,4 +1,5 @@
 mod r#async;
+mod selection;
 mod sync;
 
 pub use r#async::PyAsyncArray;

--- a/src/array/selection.rs
+++ b/src/array/selection.rs
@@ -145,8 +145,8 @@ impl PySelectionInput {
         }
 
         // Pad any remaining trailing axes (when there was no ellipsis).
-        for axis in ranges.len()..ndim {
-            ranges.push(0..shape[axis]);
+        for &len in &shape[ranges.len()..] {
+            ranges.push(0..len);
         }
 
         Ok(ArraySubset::new_with_ranges(&ranges))

--- a/src/array/selection.rs
+++ b/src/array/selection.rs
@@ -70,12 +70,12 @@ impl<'a, 'py> FromPyObject<'a, 'py> for AxisSelector {
 /// A full selection: either a single axis selector (`arr[5]`) or a tuple of them
 /// (`arr[5, 0:10, ...]`). Nested tuples are rejected.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum PySelectionInput {
+pub(crate) enum PySelection {
     Single(AxisSelector),
     Tuple(Vec<AxisSelector>),
 }
 
-impl PySelectionInput {
+impl PySelection {
     // TODO: this function is vibe coded, come back to this and clean it up.
 
     /// Resolve this selection against a concrete array `shape`, producing the
@@ -85,8 +85,8 @@ impl PySelectionInput {
     pub(crate) fn to_array_subset(&self, shape: &[u64]) -> ZarristaResult<ArraySubset> {
         let ndim = shape.len();
         let selectors: &[AxisSelector] = match self {
-            PySelectionInput::Single(sel) => std::slice::from_ref(sel),
-            PySelectionInput::Tuple(sels) => sels.as_slice(),
+            PySelection::Single(sel) => std::slice::from_ref(sel),
+            PySelection::Tuple(sels) => sels.as_slice(),
         };
 
         let n_ellipsis = selectors
@@ -153,7 +153,7 @@ impl PySelectionInput {
     }
 }
 
-impl<'a, 'py> FromPyObject<'a, 'py> for PySelectionInput {
+impl<'a, 'py> FromPyObject<'a, 'py> for PySelection {
     type Error = PyErr;
 
     fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
@@ -162,9 +162,9 @@ impl<'a, 'py> FromPyObject<'a, 'py> for PySelectionInput {
             for item in tuple.iter() {
                 axes.push(item.extract::<AxisSelector>()?);
             }
-            return Ok(PySelectionInput::Tuple(axes));
+            return Ok(PySelection::Tuple(axes));
         }
-        Ok(PySelectionInput::Single(obj.extract::<AxisSelector>()?))
+        Ok(PySelection::Single(obj.extract::<AxisSelector>()?))
     }
 }
 
@@ -177,8 +177,8 @@ mod tests {
     fn extracts_integer_index() {
         Python::attach(|py| {
             let obj = py.eval(c"5", None, None).unwrap();
-            let sel: PySelectionInput = obj.extract().unwrap();
-            assert_eq!(sel, PySelectionInput::Single(AxisSelector::Index(5)));
+            let sel: PySelection = obj.extract().unwrap();
+            assert_eq!(sel, PySelection::Single(AxisSelector::Index(5)));
         });
     }
 
@@ -186,8 +186,8 @@ mod tests {
     fn extracts_negative_integer_index() {
         Python::attach(|py| {
             let obj = py.eval(c"-1", None, None).unwrap();
-            let sel: PySelectionInput = obj.extract().unwrap();
-            assert_eq!(sel, PySelectionInput::Single(AxisSelector::Index(-1)));
+            let sel: PySelection = obj.extract().unwrap();
+            assert_eq!(sel, PySelection::Single(AxisSelector::Index(-1)));
         });
     }
 
@@ -195,10 +195,10 @@ mod tests {
     fn extracts_slice_with_start_stop() {
         Python::attach(|py| {
             let obj = py.eval(c"slice(0, 10)", None, None).unwrap();
-            let sel: PySelectionInput = obj.extract().unwrap();
+            let sel: PySelection = obj.extract().unwrap();
             assert_eq!(
                 sel,
-                PySelectionInput::Single(AxisSelector::Slice {
+                PySelection::Single(AxisSelector::Slice {
                     start: Some(0),
                     stop: Some(10),
                     step: None,
@@ -211,10 +211,10 @@ mod tests {
     fn extracts_full_slice() {
         Python::attach(|py| {
             let obj = py.eval(c"slice(None)", None, None).unwrap();
-            let sel: PySelectionInput = obj.extract().unwrap();
+            let sel: PySelection = obj.extract().unwrap();
             assert_eq!(
                 sel,
-                PySelectionInput::Single(AxisSelector::Slice {
+                PySelection::Single(AxisSelector::Slice {
                     start: None,
                     stop: None,
                     step: None,
@@ -227,10 +227,10 @@ mod tests {
     fn extracts_strided_slice() {
         Python::attach(|py| {
             let obj = py.eval(c"slice(1, 20, 2)", None, None).unwrap();
-            let sel: PySelectionInput = obj.extract().unwrap();
+            let sel: PySelection = obj.extract().unwrap();
             assert_eq!(
                 sel,
-                PySelectionInput::Single(AxisSelector::Slice {
+                PySelection::Single(AxisSelector::Slice {
                     start: Some(1),
                     stop: Some(20),
                     step: Some(2),
@@ -243,8 +243,8 @@ mod tests {
     fn extracts_ellipsis() {
         Python::attach(|py| {
             let obj = py.eval(c"...", None, None).unwrap();
-            let sel: PySelectionInput = obj.extract().unwrap();
-            assert_eq!(sel, PySelectionInput::Single(AxisSelector::Ellipsis));
+            let sel: PySelection = obj.extract().unwrap();
+            assert_eq!(sel, PySelection::Single(AxisSelector::Ellipsis));
         });
     }
 
@@ -252,10 +252,10 @@ mod tests {
     fn extracts_tuple_of_mixed() {
         Python::attach(|py| {
             let obj = py.eval(c"(5, slice(0, 4), ...)", None, None).unwrap();
-            let sel: PySelectionInput = obj.extract().unwrap();
+            let sel: PySelection = obj.extract().unwrap();
             assert_eq!(
                 sel,
-                PySelectionInput::Tuple(vec![
+                PySelection::Tuple(vec![
                     AxisSelector::Index(5),
                     AxisSelector::Slice {
                         start: Some(0),
@@ -272,8 +272,8 @@ mod tests {
     fn empty_tuple_is_empty_selection() {
         Python::attach(|py| {
             let obj = py.eval(c"()", None, None).unwrap();
-            let sel: PySelectionInput = obj.extract().unwrap();
-            assert_eq!(sel, PySelectionInput::Tuple(vec![]));
+            let sel: PySelection = obj.extract().unwrap();
+            assert_eq!(sel, PySelection::Tuple(vec![]));
         });
     }
 
@@ -281,7 +281,7 @@ mod tests {
     fn rejects_nested_tuple() {
         Python::attach(|py| {
             let obj = py.eval(c"(5, (0, 1))", None, None).unwrap();
-            let result: PyResult<PySelectionInput> = obj.extract();
+            let result: PyResult<PySelection> = obj.extract();
             assert!(result.is_err());
         });
     }
@@ -290,7 +290,7 @@ mod tests {
     fn rejects_none_as_newaxis() {
         Python::attach(|py| {
             let obj = py.eval(c"None", None, None).unwrap();
-            let err = obj.extract::<PySelectionInput>().unwrap_err();
+            let err = obj.extract::<PySelection>().unwrap_err();
             assert!(err.is_instance_of::<PyNotImplementedError>(py));
         });
     }
@@ -300,7 +300,7 @@ mod tests {
         Python::attach(|py| {
             // `bool` is an `int` subclass; it must not be read as an integer index.
             let obj = py.eval(c"True", None, None).unwrap();
-            let err = obj.extract::<PySelectionInput>().unwrap_err();
+            let err = obj.extract::<PySelection>().unwrap_err();
             assert!(err.is_instance_of::<PyNotImplementedError>(py));
         });
     }
@@ -309,7 +309,7 @@ mod tests {
     fn rejects_list_index() {
         Python::attach(|py| {
             let obj = py.eval(c"[1, 2, 3]", None, None).unwrap();
-            let result: PyResult<PySelectionInput> = obj.extract();
+            let result: PyResult<PySelection> = obj.extract();
             assert!(result.is_err());
         });
     }
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn resolves_int_with_trailing_axes_full() {
-        let input = PySelectionInput::Single(AxisSelector::Index(5));
+        let input = PySelection::Single(AxisSelector::Index(5));
         assert_eq!(
             input.to_array_subset(SHAPE).unwrap(),
             subset(&[5..6, 0..64, 0..100])
@@ -337,7 +337,7 @@ mod tests {
 
     #[test]
     fn resolves_negative_int() {
-        let input = PySelectionInput::Single(AxisSelector::Index(-1));
+        let input = PySelection::Single(AxisSelector::Index(-1));
         assert_eq!(
             input.to_array_subset(SHAPE).unwrap(),
             subset(&[8..9, 0..64, 0..100])
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn resolves_tuple_int_and_slice() {
         let input =
-            PySelectionInput::Tuple(vec![AxisSelector::Index(5), slice(Some(0), Some(4), None)]);
+            PySelection::Tuple(vec![AxisSelector::Index(5), slice(Some(0), Some(4), None)]);
         assert_eq!(
             input.to_array_subset(SHAPE).unwrap(),
             subset(&[5..6, 0..4, 0..100])
@@ -356,7 +356,7 @@ mod tests {
 
     #[test]
     fn resolves_full_slice() {
-        let input = PySelectionInput::Single(slice(None, None, None));
+        let input = PySelection::Single(slice(None, None, None));
         assert_eq!(
             input.to_array_subset(SHAPE).unwrap(),
             subset(&[0..9, 0..64, 0..100])
@@ -365,7 +365,7 @@ mod tests {
 
     #[test]
     fn resolves_negative_slice_start() {
-        let input = PySelectionInput::Single(slice(Some(-2), None, None));
+        let input = PySelection::Single(slice(Some(-2), None, None));
         assert_eq!(
             input.to_array_subset(SHAPE).unwrap(),
             subset(&[7..9, 0..64, 0..100])
@@ -374,7 +374,7 @@ mod tests {
 
     #[test]
     fn resolves_empty_range_slice() {
-        let input = PySelectionInput::Single(slice(Some(5), Some(5), None));
+        let input = PySelection::Single(slice(Some(5), Some(5), None));
         assert_eq!(
             input.to_array_subset(SHAPE).unwrap(),
             subset(&[5..5, 0..64, 0..100])
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn resolves_ellipsis_in_middle() {
-        let input = PySelectionInput::Tuple(vec![
+        let input = PySelection::Tuple(vec![
             AxisSelector::Index(5),
             AxisSelector::Ellipsis,
             AxisSelector::Index(3),
@@ -396,7 +396,7 @@ mod tests {
 
     #[test]
     fn resolves_single_ellipsis_all_full() {
-        let input = PySelectionInput::Single(AxisSelector::Ellipsis);
+        let input = PySelection::Single(AxisSelector::Ellipsis);
         assert_eq!(
             input.to_array_subset(SHAPE).unwrap(),
             subset(&[0..9, 0..64, 0..100])
@@ -405,7 +405,7 @@ mod tests {
 
     #[test]
     fn resolves_empty_tuple_all_full() {
-        let input = PySelectionInput::Tuple(vec![]);
+        let input = PySelection::Tuple(vec![]);
         assert_eq!(
             input.to_array_subset(SHAPE).unwrap(),
             subset(&[0..9, 0..64, 0..100])
@@ -413,14 +413,14 @@ mod tests {
     }
 
     /// The Python exception produced by a failed resolution, for type checks.
-    fn resolve_err(input: &PySelectionInput) -> PyErr {
+    fn resolve_err(input: &PySelection) -> PyErr {
         input.to_array_subset(SHAPE).unwrap_err().into()
     }
 
     #[test]
     fn out_of_bounds_positive_int_errors() {
         Python::attach(|py| {
-            let input = PySelectionInput::Single(AxisSelector::Index(9)); // len 9 -> max valid 8
+            let input = PySelection::Single(AxisSelector::Index(9)); // len 9 -> max valid 8
             assert!(resolve_err(&input).is_instance_of::<PyIndexError>(py));
         });
     }
@@ -428,7 +428,7 @@ mod tests {
     #[test]
     fn out_of_bounds_negative_int_errors() {
         Python::attach(|py| {
-            let input = PySelectionInput::Single(AxisSelector::Index(-10)); // -10 + 9 = -1
+            let input = PySelection::Single(AxisSelector::Index(-10)); // -10 + 9 = -1
             assert!(resolve_err(&input).is_instance_of::<PyIndexError>(py));
         });
     }
@@ -436,7 +436,7 @@ mod tests {
     #[test]
     fn slice_with_step_errors() {
         Python::attach(|py| {
-            let input = PySelectionInput::Single(slice(None, None, Some(2)));
+            let input = PySelection::Single(slice(None, None, Some(2)));
             assert!(resolve_err(&input).is_instance_of::<PyNotImplementedError>(py));
         });
     }
@@ -444,7 +444,7 @@ mod tests {
     #[test]
     fn too_many_indices_errors() {
         Python::attach(|py| {
-            let input = PySelectionInput::Tuple(vec![
+            let input = PySelection::Tuple(vec![
                 AxisSelector::Index(0),
                 AxisSelector::Index(0),
                 AxisSelector::Index(0),
@@ -458,7 +458,7 @@ mod tests {
     fn double_ellipsis_errors() {
         Python::attach(|py| {
             let input =
-                PySelectionInput::Tuple(vec![AxisSelector::Ellipsis, AxisSelector::Ellipsis]);
+                PySelection::Tuple(vec![AxisSelector::Ellipsis, AxisSelector::Ellipsis]);
             assert!(resolve_err(&input).is_instance_of::<PyIndexError>(py));
         });
     }

--- a/src/array/selection.rs
+++ b/src/array/selection.rs
@@ -5,10 +5,15 @@
 //! it against a concrete array shape (resolving negatives, expanding `Ellipsis`,
 //! building an `ArraySubset`) is a separate, shape-aware step.
 
-use pyo3::exceptions::PyNotImplementedError;
+use std::ops::Range;
+
+use pyo3::exceptions::{PyIndexError, PyNotImplementedError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyEllipsis, PySlice, PyTuple};
 use pyo3::Borrowed;
+use zarrs::array::ArraySubset;
+
+use crate::error::ZarristaResult;
 
 /// A selector for a single axis, as written inside `[]`.
 ///
@@ -70,6 +75,84 @@ pub(crate) enum PySelectionInput {
     Tuple(Vec<AxisSelector>),
 }
 
+impl PySelectionInput {
+    // TODO: this function is vibe coded, come back to this and clean it up.
+
+    /// Resolve this selection against a concrete array `shape`, producing the
+    /// `ArraySubset` to read. Negative indices and slice bounds are normalized,
+    /// a single `Ellipsis` (or fewer-than-`ndim` selectors) expands to full
+    /// axes, and an integer selects a length-1 range (the axis is retained).
+    pub(crate) fn to_array_subset(&self, shape: &[u64]) -> ZarristaResult<ArraySubset> {
+        let ndim = shape.len();
+        let selectors: &[AxisSelector] = match self {
+            PySelectionInput::Single(sel) => std::slice::from_ref(sel),
+            PySelectionInput::Tuple(sels) => sels.as_slice(),
+        };
+
+        let n_ellipsis = selectors
+            .iter()
+            .filter(|s| matches!(s, AxisSelector::Ellipsis))
+            .count();
+        if n_ellipsis > 1 {
+            return Err(
+                PyIndexError::new_err("an index can only have a single ellipsis ('...')").into(),
+            );
+        }
+        let n_explicit = selectors.len() - n_ellipsis;
+        if n_explicit > ndim {
+            return Err(PyIndexError::new_err(format!(
+                "too many indices for array: array is {ndim}-dimensional, but {n_explicit} were indexed"
+            ))
+            .into());
+        }
+        let n_fill = ndim - n_explicit;
+
+        let mut ranges: Vec<Range<u64>> = Vec::with_capacity(ndim);
+        for sel in selectors {
+            let axis = ranges.len();
+            match sel {
+                AxisSelector::Ellipsis => {
+                    for d in 0..n_fill {
+                        ranges.push(0..shape[axis + d]);
+                    }
+                }
+                AxisSelector::Index(i) => {
+                    let len = shape[axis] as i64;
+                    let resolved = if *i < 0 { *i + len } else { *i };
+                    if resolved < 0 || resolved >= len {
+                        return Err(PyIndexError::new_err(format!(
+                            "index {i} is out of bounds for axis {axis} with size {}",
+                            shape[axis]
+                        ))
+                        .into());
+                    }
+                    ranges.push(resolved as u64..resolved as u64 + 1);
+                }
+                AxisSelector::Slice { start, stop, step } => {
+                    if step.is_some_and(|s| s != 1) {
+                        return Err(PyNotImplementedError::new_err(
+                            "slices with a step other than 1 are not supported",
+                        )
+                        .into());
+                    }
+                    let len = shape[axis] as i64;
+                    let norm = |v: i64| if v < 0 { (v + len).max(0) } else { v.min(len) };
+                    let lo = start.map_or(0, norm);
+                    let hi = stop.map_or(len, norm).max(lo);
+                    ranges.push(lo as u64..hi as u64);
+                }
+            }
+        }
+
+        // Pad any remaining trailing axes (when there was no ellipsis).
+        for axis in ranges.len()..ndim {
+            ranges.push(0..shape[axis]);
+        }
+
+        Ok(ArraySubset::new_with_ranges(&ranges))
+    }
+}
+
 impl<'a, 'py> FromPyObject<'a, 'py> for PySelectionInput {
     type Error = PyErr;
 
@@ -88,7 +171,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for PySelectionInput {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pyo3::exceptions::PyNotImplementedError;
+    use pyo3::exceptions::{PyIndexError, PyNotImplementedError};
 
     #[test]
     fn extracts_integer_index() {
@@ -228,6 +311,155 @@ mod tests {
             let obj = py.eval(c"[1, 2, 3]", None, None).unwrap();
             let result: PyResult<PySelectionInput> = obj.extract();
             assert!(result.is_err());
+        });
+    }
+
+    // --- to_array_subset: shape resolution ---
+
+    const SHAPE: &[u64] = &[9, 64, 100];
+
+    fn subset(ranges: &[Range<u64>]) -> ArraySubset {
+        ArraySubset::new_with_ranges(ranges)
+    }
+
+    fn slice(start: Option<i64>, stop: Option<i64>, step: Option<i64>) -> AxisSelector {
+        AxisSelector::Slice { start, stop, step }
+    }
+
+    #[test]
+    fn resolves_int_with_trailing_axes_full() {
+        let input = PySelectionInput::Single(AxisSelector::Index(5));
+        assert_eq!(
+            input.to_array_subset(SHAPE).unwrap(),
+            subset(&[5..6, 0..64, 0..100])
+        );
+    }
+
+    #[test]
+    fn resolves_negative_int() {
+        let input = PySelectionInput::Single(AxisSelector::Index(-1));
+        assert_eq!(
+            input.to_array_subset(SHAPE).unwrap(),
+            subset(&[8..9, 0..64, 0..100])
+        );
+    }
+
+    #[test]
+    fn resolves_tuple_int_and_slice() {
+        let input =
+            PySelectionInput::Tuple(vec![AxisSelector::Index(5), slice(Some(0), Some(4), None)]);
+        assert_eq!(
+            input.to_array_subset(SHAPE).unwrap(),
+            subset(&[5..6, 0..4, 0..100])
+        );
+    }
+
+    #[test]
+    fn resolves_full_slice() {
+        let input = PySelectionInput::Single(slice(None, None, None));
+        assert_eq!(
+            input.to_array_subset(SHAPE).unwrap(),
+            subset(&[0..9, 0..64, 0..100])
+        );
+    }
+
+    #[test]
+    fn resolves_negative_slice_start() {
+        let input = PySelectionInput::Single(slice(Some(-2), None, None));
+        assert_eq!(
+            input.to_array_subset(SHAPE).unwrap(),
+            subset(&[7..9, 0..64, 0..100])
+        );
+    }
+
+    #[test]
+    fn resolves_empty_range_slice() {
+        let input = PySelectionInput::Single(slice(Some(5), Some(5), None));
+        assert_eq!(
+            input.to_array_subset(SHAPE).unwrap(),
+            subset(&[5..5, 0..64, 0..100])
+        );
+    }
+
+    #[test]
+    fn resolves_ellipsis_in_middle() {
+        let input = PySelectionInput::Tuple(vec![
+            AxisSelector::Index(5),
+            AxisSelector::Ellipsis,
+            AxisSelector::Index(3),
+        ]);
+        assert_eq!(
+            input.to_array_subset(SHAPE).unwrap(),
+            subset(&[5..6, 0..64, 3..4])
+        );
+    }
+
+    #[test]
+    fn resolves_single_ellipsis_all_full() {
+        let input = PySelectionInput::Single(AxisSelector::Ellipsis);
+        assert_eq!(
+            input.to_array_subset(SHAPE).unwrap(),
+            subset(&[0..9, 0..64, 0..100])
+        );
+    }
+
+    #[test]
+    fn resolves_empty_tuple_all_full() {
+        let input = PySelectionInput::Tuple(vec![]);
+        assert_eq!(
+            input.to_array_subset(SHAPE).unwrap(),
+            subset(&[0..9, 0..64, 0..100])
+        );
+    }
+
+    /// The Python exception produced by a failed resolution, for type checks.
+    fn resolve_err(input: &PySelectionInput) -> PyErr {
+        input.to_array_subset(SHAPE).unwrap_err().into()
+    }
+
+    #[test]
+    fn out_of_bounds_positive_int_errors() {
+        Python::attach(|py| {
+            let input = PySelectionInput::Single(AxisSelector::Index(9)); // len 9 -> max valid 8
+            assert!(resolve_err(&input).is_instance_of::<PyIndexError>(py));
+        });
+    }
+
+    #[test]
+    fn out_of_bounds_negative_int_errors() {
+        Python::attach(|py| {
+            let input = PySelectionInput::Single(AxisSelector::Index(-10)); // -10 + 9 = -1
+            assert!(resolve_err(&input).is_instance_of::<PyIndexError>(py));
+        });
+    }
+
+    #[test]
+    fn slice_with_step_errors() {
+        Python::attach(|py| {
+            let input = PySelectionInput::Single(slice(None, None, Some(2)));
+            assert!(resolve_err(&input).is_instance_of::<PyNotImplementedError>(py));
+        });
+    }
+
+    #[test]
+    fn too_many_indices_errors() {
+        Python::attach(|py| {
+            let input = PySelectionInput::Tuple(vec![
+                AxisSelector::Index(0),
+                AxisSelector::Index(0),
+                AxisSelector::Index(0),
+                AxisSelector::Index(0), // 4 indices for a 3-D array
+            ]);
+            assert!(resolve_err(&input).is_instance_of::<PyIndexError>(py));
+        });
+    }
+
+    #[test]
+    fn double_ellipsis_errors() {
+        Python::attach(|py| {
+            let input =
+                PySelectionInput::Tuple(vec![AxisSelector::Ellipsis, AxisSelector::Ellipsis]);
+            assert!(resolve_err(&input).is_instance_of::<PyIndexError>(py));
         });
     }
 }

--- a/src/array/selection.rs
+++ b/src/array/selection.rs
@@ -346,8 +346,7 @@ mod tests {
 
     #[test]
     fn resolves_tuple_int_and_slice() {
-        let input =
-            PySelection::Tuple(vec![AxisSelector::Index(5), slice(Some(0), Some(4), None)]);
+        let input = PySelection::Tuple(vec![AxisSelector::Index(5), slice(Some(0), Some(4), None)]);
         assert_eq!(
             input.to_array_subset(SHAPE).unwrap(),
             subset(&[5..6, 0..4, 0..100])
@@ -457,8 +456,7 @@ mod tests {
     #[test]
     fn double_ellipsis_errors() {
         Python::attach(|py| {
-            let input =
-                PySelection::Tuple(vec![AxisSelector::Ellipsis, AxisSelector::Ellipsis]);
+            let input = PySelection::Tuple(vec![AxisSelector::Ellipsis, AxisSelector::Ellipsis]);
             assert!(resolve_err(&input).is_instance_of::<PyIndexError>(py));
         });
     }

--- a/src/array/selection.rs
+++ b/src/array/selection.rs
@@ -1,0 +1,233 @@
+//! Parsing of Python selection objects — the argument to `__getitem__` and
+//! `retrieve_array_subset` — into a shape-independent Rust representation.
+//!
+//! This module only models *what was written* inside the brackets. Normalizing
+//! it against a concrete array shape (resolving negatives, expanding `Ellipsis`,
+//! building an `ArraySubset`) is a separate, shape-aware step.
+
+use pyo3::exceptions::PyNotImplementedError;
+use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyEllipsis, PySlice, PyTuple};
+use pyo3::Borrowed;
+
+/// A selector for a single axis, as written inside `[]`.
+///
+/// Values are captured verbatim; negative indices and slice bounds are *not* yet
+/// normalized against the axis length.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AxisSelector {
+    /// An integer index, e.g. `5` or `-1`.
+    Index(i64),
+    /// A slice, e.g. `0:10`, `::`, or `:5`.
+    Slice {
+        start: Option<i64>,
+        stop: Option<i64>,
+        step: Option<i64>,
+    },
+    /// `...` (Ellipsis).
+    Ellipsis,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for AxisSelector {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if obj.is_none() {
+            return Err(PyNotImplementedError::new_err(
+                "None / np.newaxis indexing is not supported",
+            ));
+        }
+
+        // `bool` is a subclass of `int`; reject it before integer extraction so
+        // boolean indexing is not silently read as 0/1.
+        if obj.cast::<PyBool>().is_ok() {
+            return Err(PyNotImplementedError::new_err(
+                "boolean indexing is not supported",
+            ));
+        }
+
+        if obj.cast::<PyEllipsis>().is_ok() {
+            return Ok(AxisSelector::Ellipsis);
+        }
+
+        if let Ok(slice) = obj.cast::<PySlice>() {
+            return Ok(AxisSelector::Slice {
+                start: slice.getattr("start")?.extract()?,
+                stop: slice.getattr("stop")?.extract()?,
+                step: slice.getattr("step")?.extract()?,
+            });
+        }
+
+        Ok(AxisSelector::Index(obj.extract::<i64>()?))
+    }
+}
+
+/// A full selection: either a single axis selector (`arr[5]`) or a tuple of them
+/// (`arr[5, 0:10, ...]`). Nested tuples are rejected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PySelectionInput {
+    Single(AxisSelector),
+    Tuple(Vec<AxisSelector>),
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for PySelectionInput {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(tuple) = obj.cast::<PyTuple>() {
+            let mut axes = Vec::with_capacity(tuple.len());
+            for item in tuple.iter() {
+                axes.push(item.extract::<AxisSelector>()?);
+            }
+            return Ok(PySelectionInput::Tuple(axes));
+        }
+        Ok(PySelectionInput::Single(obj.extract::<AxisSelector>()?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::exceptions::PyNotImplementedError;
+
+    #[test]
+    fn extracts_integer_index() {
+        Python::attach(|py| {
+            let obj = py.eval(c"5", None, None).unwrap();
+            let sel: PySelectionInput = obj.extract().unwrap();
+            assert_eq!(sel, PySelectionInput::Single(AxisSelector::Index(5)));
+        });
+    }
+
+    #[test]
+    fn extracts_negative_integer_index() {
+        Python::attach(|py| {
+            let obj = py.eval(c"-1", None, None).unwrap();
+            let sel: PySelectionInput = obj.extract().unwrap();
+            assert_eq!(sel, PySelectionInput::Single(AxisSelector::Index(-1)));
+        });
+    }
+
+    #[test]
+    fn extracts_slice_with_start_stop() {
+        Python::attach(|py| {
+            let obj = py.eval(c"slice(0, 10)", None, None).unwrap();
+            let sel: PySelectionInput = obj.extract().unwrap();
+            assert_eq!(
+                sel,
+                PySelectionInput::Single(AxisSelector::Slice {
+                    start: Some(0),
+                    stop: Some(10),
+                    step: None,
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn extracts_full_slice() {
+        Python::attach(|py| {
+            let obj = py.eval(c"slice(None)", None, None).unwrap();
+            let sel: PySelectionInput = obj.extract().unwrap();
+            assert_eq!(
+                sel,
+                PySelectionInput::Single(AxisSelector::Slice {
+                    start: None,
+                    stop: None,
+                    step: None,
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn extracts_strided_slice() {
+        Python::attach(|py| {
+            let obj = py.eval(c"slice(1, 20, 2)", None, None).unwrap();
+            let sel: PySelectionInput = obj.extract().unwrap();
+            assert_eq!(
+                sel,
+                PySelectionInput::Single(AxisSelector::Slice {
+                    start: Some(1),
+                    stop: Some(20),
+                    step: Some(2),
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn extracts_ellipsis() {
+        Python::attach(|py| {
+            let obj = py.eval(c"...", None, None).unwrap();
+            let sel: PySelectionInput = obj.extract().unwrap();
+            assert_eq!(sel, PySelectionInput::Single(AxisSelector::Ellipsis));
+        });
+    }
+
+    #[test]
+    fn extracts_tuple_of_mixed() {
+        Python::attach(|py| {
+            let obj = py.eval(c"(5, slice(0, 4), ...)", None, None).unwrap();
+            let sel: PySelectionInput = obj.extract().unwrap();
+            assert_eq!(
+                sel,
+                PySelectionInput::Tuple(vec![
+                    AxisSelector::Index(5),
+                    AxisSelector::Slice {
+                        start: Some(0),
+                        stop: Some(4),
+                        step: None,
+                    },
+                    AxisSelector::Ellipsis,
+                ])
+            );
+        });
+    }
+
+    #[test]
+    fn empty_tuple_is_empty_selection() {
+        Python::attach(|py| {
+            let obj = py.eval(c"()", None, None).unwrap();
+            let sel: PySelectionInput = obj.extract().unwrap();
+            assert_eq!(sel, PySelectionInput::Tuple(vec![]));
+        });
+    }
+
+    #[test]
+    fn rejects_nested_tuple() {
+        Python::attach(|py| {
+            let obj = py.eval(c"(5, (0, 1))", None, None).unwrap();
+            let result: PyResult<PySelectionInput> = obj.extract();
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn rejects_none_as_newaxis() {
+        Python::attach(|py| {
+            let obj = py.eval(c"None", None, None).unwrap();
+            let err = obj.extract::<PySelectionInput>().unwrap_err();
+            assert!(err.is_instance_of::<PyNotImplementedError>(py));
+        });
+    }
+
+    #[test]
+    fn rejects_bool_index() {
+        Python::attach(|py| {
+            // `bool` is an `int` subclass; it must not be read as an integer index.
+            let obj = py.eval(c"True", None, None).unwrap();
+            let err = obj.extract::<PySelectionInput>().unwrap_err();
+            assert!(err.is_instance_of::<PyNotImplementedError>(py));
+        });
+    }
+
+    #[test]
+    fn rejects_list_index() {
+        Python::attach(|py| {
+            let obj = py.eval(c"[1, 2, 3]", None, None).unwrap();
+            let result: PyResult<PySelectionInput> = obj.extract();
+            assert!(result.is_err());
+        });
+    }
+}

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -1,8 +1,9 @@
 //! The `Array` Python class: metadata accessors and numpy-style reads.
 
+use crate::array::selection::PySelectionInput;
 use crate::chunks::PyChunkGrid;
 use crate::codec::PyCodecChain;
-use crate::data::{DataInner, PyData};
+use crate::data::{for_each_dtype, DataInner, PyData};
 use crate::dtype::PyDataType;
 use crate::error::ZarristaResult;
 use crate::node::PyNodePath;
@@ -94,12 +95,42 @@ impl PyArray {
         self.inner.path().as_str()
     }
 
+    /// Read a region of the array as `Data`, using numpy-style basic indexing.
+    fn retrieve_array_subset(&self, selection: PySelectionInput) -> ZarristaResult<PyData> {
+        use zarrs::array::data_type::*;
+
+        let array_subset = selection.to_array_subset(self.inner.shape())?;
+        let dtype = self.inner.data_type();
+
+        macro_rules! arm {
+            ($dtype:ty, $variant:ident, $elem:ty) => {
+                if dtype.is::<$dtype>() {
+                    let data = self
+                        .inner
+                        .retrieve_array_subset::<ArrayD<$elem>>(&array_subset)?;
+                    return Ok(PyData::from(DataInner::$variant(data)));
+                }
+            };
+        }
+        for_each_dtype!(arm);
+
+        Err(PyNotImplementedError::new_err(format!(
+            "reading data type {dtype} is not supported yet"
+        ))
+        .into())
+    }
+
+    /// Read a region with numpy-style basic indexing, e.g. `arr[0:10, :, 5]`.
+    fn __getitem__(&self, selection: PySelectionInput) -> ZarristaResult<PyData> {
+        self.retrieve_array_subset(selection)
+    }
+
     fn retrieve_chunk(&self, chunk_indices: Vec<u64>) -> ZarristaResult<PyData> {
         use zarrs::array::data_type::*;
 
         let dtype = self.inner.data_type();
 
-        macro_rules! retrieve {
+        macro_rules! arm {
             ($dtype:ty, $variant:ident, $elem:ty) => {
                 if dtype.is::<$dtype>() {
                     let chunk = self.inner.retrieve_chunk::<ArrayD<$elem>>(&chunk_indices)?;
@@ -107,19 +138,7 @@ impl PyArray {
                 }
             };
         }
-
-        retrieve!(BoolDataType, Bool, bool);
-        retrieve!(Int8DataType, Int8, i8);
-        retrieve!(Int16DataType, Int16, i16);
-        retrieve!(Int32DataType, Int32, i32);
-        retrieve!(Int64DataType, Int64, i64);
-        retrieve!(UInt8DataType, Uint8, u8);
-        retrieve!(UInt16DataType, Uint16, u16);
-        retrieve!(UInt32DataType, Uint32, u32);
-        retrieve!(UInt64DataType, Uint64, u64);
-        retrieve!(Float16DataType, Float16, half::f16);
-        retrieve!(Float32DataType, Float32, f32);
-        retrieve!(Float64DataType, Float64, f64);
+        for_each_dtype!(arm);
 
         Err(PyNotImplementedError::new_err(format!(
             "reading data type {dtype} is not supported yet"

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -1,6 +1,6 @@
 //! The `Array` Python class: metadata accessors and numpy-style reads.
 
-use crate::array::selection::PySelectionInput;
+use crate::array::selection::PySelection;
 use crate::chunks::PyChunkGrid;
 use crate::codec::PyCodecChain;
 use crate::data::{for_each_dtype, DataInner, PyData};
@@ -96,7 +96,7 @@ impl PyArray {
     }
 
     /// Read a region of the array as `Data`, using numpy-style basic indexing.
-    fn retrieve_array_subset(&self, selection: PySelectionInput) -> ZarristaResult<PyData> {
+    fn retrieve_array_subset(&self, selection: PySelection) -> ZarristaResult<PyData> {
         use zarrs::array::data_type::*;
 
         let array_subset = selection.to_array_subset(self.inner.shape())?;
@@ -121,7 +121,7 @@ impl PyArray {
     }
 
     /// Read a region with numpy-style basic indexing, e.g. `arr[0:10, :, 5]`.
-    fn __getitem__(&self, selection: PySelectionInput) -> ZarristaResult<PyData> {
+    fn __getitem__(&self, selection: PySelection) -> ZarristaResult<PyData> {
         self.retrieve_array_subset(selection)
     }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -41,7 +41,7 @@ use pyo3::prelude::*;
 
 /// The decoded data of a chunk, with variants for each supported dtype.
 ///
-/// This is kept separate from `PyData` 1) because Python classes can't be defined as Rust enums and 2) so that we have a clean place to manage data types not supported by numpy.
+/// This is kept separate from `PyData` 1. because Python classes can't be defined as Rust enums and 2. so that we have a clean place to manage data types not supported by numpy.
 pub enum DataInner {
     Bool(ArrayD<bool>),
     Float16(ArrayD<half::f16>),
@@ -56,6 +56,31 @@ pub enum DataInner {
     Uint64(ArrayD<u64>),
     Uint8(ArrayD<u8>),
 }
+
+/// Invoke `$arm!(ZarrsDataType, DataInnerVariant, rust_elem_type)` once per
+/// supported dtype. The caller supplies an `arm!` macro that turns a single
+/// `(dtype, variant, elem)` triple into a retrieval (e.g. `retrieve_chunk` or
+/// `retrieve_array_subset`), keeping the dtype list defined in exactly one place.
+///
+/// The `ZarrsDataType` idents (e.g. `BoolDataType`) and `half::f16` are resolved
+/// in the caller's scope, so callers must have `use zarrs::array::data_type::*`.
+macro_rules! for_each_dtype {
+    ($arm:ident) => {
+        $arm!(BoolDataType, Bool, bool);
+        $arm!(Int8DataType, Int8, i8);
+        $arm!(Int16DataType, Int16, i16);
+        $arm!(Int32DataType, Int32, i32);
+        $arm!(Int64DataType, Int64, i64);
+        $arm!(UInt8DataType, Uint8, u8);
+        $arm!(UInt16DataType, Uint16, u16);
+        $arm!(UInt32DataType, Uint32, u32);
+        $arm!(UInt64DataType, Uint64, u64);
+        $arm!(Float16DataType, Float16, half::f16);
+        $arm!(Float32DataType, Float32, f32);
+        $arm!(Float64DataType, Float64, f64);
+    };
+}
+pub(crate) use for_each_dtype;
 
 /// Run `$body` against the inner `ArrayD`, with `$a` bound to it regardless of
 /// element type. Exhaustive, so a new `DataInner` variant is a compile error.

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,0 +1,114 @@
+"""Array indexing: read regions with zarrista and compare against zarr-python.
+
+Fixtures are written with zarr-python, read back with zarrista, and the decoded
+region is compared to the equivalent numpy slice. This doubles as a round-trip
+compatibility check between the two implementations.
+"""
+
+import asyncio
+
+import numpy as np
+import pytest
+import zarr
+from obstore.store import LocalStore
+from zarrista import Array, AsyncArray, FilesystemStore
+
+
+@pytest.fixture
+def int32_array(tmp_path):
+    """A (9, 64, 100) int32 array written with zarr-python; returns (path, data)."""
+    path = tmp_path / "a.zarr"
+    data = np.arange(9 * 64 * 100, dtype="int32").reshape(9, 64, 100)
+    z = zarr.create_array(
+        store=str(path), shape=data.shape, chunks=(3, 16, 50), dtype=data.dtype
+    )
+    z[:] = data
+    return path, data
+
+
+def test_slice_read_matches_numpy(int32_array):
+    path, data = int32_array
+    arr = Array.open(FilesystemStore(str(path)))
+
+    result = arr.retrieve_array_subset(
+        (slice(0, 2), slice(None), slice(5, 7))
+    ).to_numpy()
+
+    np.testing.assert_array_equal(result, data[0:2, :, 5:7])
+
+
+def test_getitem_matches_retrieve_array_subset(int32_array):
+    path, data = int32_array
+    arr = Array.open(FilesystemStore(str(path)))
+
+    key = (slice(0, 2), slice(None), slice(5, 7))
+    np.testing.assert_array_equal(
+        arr[key].to_numpy(), arr.retrieve_array_subset(key).to_numpy()
+    )
+
+
+def test_int_index_retains_axis(int32_array):
+    """ndim-preserving (zarrs-consistent): an int keeps a length-1 axis."""
+    path, data = int32_array
+    arr = Array.open(FilesystemStore(str(path)))
+
+    result = arr[5].to_numpy()
+    assert result.shape == (1, 64, 100)
+    np.testing.assert_array_equal(result, data[5:6])
+
+
+def test_negative_index(int32_array):
+    path, data = int32_array
+    arr = Array.open(FilesystemStore(str(path)))
+    np.testing.assert_array_equal(arr[-1].to_numpy(), data[8:9])
+
+
+def test_ellipsis(int32_array):
+    path, data = int32_array
+    arr = Array.open(FilesystemStore(str(path)))
+    result = arr[5, ..., 3].to_numpy()
+    np.testing.assert_array_equal(result, data[5:6, :, 3:4])
+
+
+def test_full_array(int32_array):
+    path, data = int32_array
+    arr = Array.open(FilesystemStore(str(path)))
+    np.testing.assert_array_equal(arr[...].to_numpy(), data)
+
+
+def test_out_of_bounds_int_raises(int32_array):
+    path, _ = int32_array
+    arr = Array.open(FilesystemStore(str(path)))
+    with pytest.raises(IndexError):
+        arr[9]  # axis 0 has size 9 -> max valid index is 8
+
+
+def test_step_not_one_raises(int32_array):
+    path, _ = int32_array
+    arr = Array.open(FilesystemStore(str(path)))
+    with pytest.raises(NotImplementedError):
+        arr[0:9:2]
+
+
+def test_float64_dtype(tmp_path):
+    """Exercise the dtype dispatch on a non-integer type."""
+    path = tmp_path / "f.zarr"
+    data = (np.arange(4 * 5, dtype="float64") * 0.5).reshape(4, 5)
+    z = zarr.create_array(
+        store=str(path), shape=data.shape, chunks=(2, 5), dtype=data.dtype
+    )
+    z[:] = data
+
+    arr = Array.open(FilesystemStore(str(path)))
+    np.testing.assert_array_equal(arr[1:3, 0:4].to_numpy(), data[1:3, 0:4])
+
+
+def test_async_getitem_matches_numpy(int32_array):
+    """The async path (obstore + `await arr[...]`) returns the same region."""
+    path, data = int32_array
+
+    async def read():
+        arr = await AsyncArray.open_async(LocalStore(str(path)))
+        return (await arr[0:2, :, 5:7]).to_numpy()
+
+    np.testing.assert_array_equal(asyncio.run(read()), data[0:2, :, 5:7])


### PR DESCRIPTION
### Change list

- Adds `Array.retrieve_array_subset`, `Array.__getitem__` and async counterparts. You need to `await` the result of `__getitem__` on `AsyncArray`
- Defines `PySelection`, i.e. numpy-like indexing that handles integers, slices, and ellipses.
- Update home page README