### PR TITLE
FilesystemStore supports Pathlib input

### DIFF
--- a/python/zarrista/_store.pyi
+++ b/python/zarrista/_store.pyi
@@ -1,7 +1,9 @@
+from pathlib import Path
+
 class FilesystemStore:
     """A store backed by a local directory."""
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str | Path) -> None:
         """Open a filesystem store rooted at `path`."""
     def __repr__(self) -> str: ...
 

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -1,6 +1,7 @@
 use crate::error::ZarristaResult;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
+use std::path::PathBuf;
 use std::sync::Arc;
 use zarrs::filesystem::FilesystemStore;
 use zarrs::storage::store::MemoryStore;
@@ -25,7 +26,7 @@ pub struct PyFilesystemStore {
 impl PyFilesystemStore {
     /// Open a filesystem store rooted at `path`.
     #[new]
-    fn new(path: &str) -> ZarristaResult<Self> {
+    fn new(path: PathBuf) -> ZarristaResult<Self> {
         let store = FilesystemStore::new(path)?;
         Ok(Self {
             storage: Arc::new(store),

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -6,16 +6,18 @@ compatibility check between the two implementations.
 """
 
 import asyncio
+from pathlib import Path
 
 import numpy as np
 import pytest
 import zarr
+from numpy.typing import NDArray
 from obstore.store import LocalStore
 from zarrista import Array, AsyncArray, FilesystemStore
 
 
 @pytest.fixture
-def int32_array(tmp_path):
+def int32_array(tmp_path: Path) -> tuple[Path, NDArray[np.int32]]:
     """A (9, 64, 100) int32 array written with zarr-python; returns (path, data)."""
     path = tmp_path / "a.zarr"
     data = np.arange(9 * 64 * 100, dtype="int32").reshape(9, 64, 100)
@@ -26,9 +28,9 @@ def int32_array(tmp_path):
     return path, data
 
 
-def test_slice_read_matches_numpy(int32_array):
+def test_slice_read_matches_numpy(int32_array: tuple[Path, NDArray[np.int32]]):
     path, data = int32_array
-    arr = Array.open(FilesystemStore(str(path)))
+    arr = Array.open(FilesystemStore(path))
 
     result = arr.retrieve_array_subset(
         (slice(0, 2), slice(None), slice(5, 7))
@@ -37,9 +39,11 @@ def test_slice_read_matches_numpy(int32_array):
     np.testing.assert_array_equal(result, data[0:2, :, 5:7])
 
 
-def test_getitem_matches_retrieve_array_subset(int32_array):
+def test_getitem_matches_retrieve_array_subset(
+    int32_array: tuple[Path, NDArray[np.int32]],
+):
     path, data = int32_array
-    arr = Array.open(FilesystemStore(str(path)))
+    arr = Array.open(FilesystemStore(path))
 
     key = (slice(0, 2), slice(None), slice(5, 7))
     np.testing.assert_array_equal(
@@ -47,45 +51,45 @@ def test_getitem_matches_retrieve_array_subset(int32_array):
     )
 
 
-def test_int_index_retains_axis(int32_array):
+def test_int_index_retains_axis(int32_array: tuple[Path, NDArray[np.int32]]):
     """ndim-preserving (zarrs-consistent): an int keeps a length-1 axis."""
     path, data = int32_array
-    arr = Array.open(FilesystemStore(str(path)))
+    arr = Array.open(FilesystemStore(path))
 
     result = arr[5].to_numpy()
     assert result.shape == (1, 64, 100)
     np.testing.assert_array_equal(result, data[5:6])
 
 
-def test_negative_index(int32_array):
+def test_negative_index(int32_array: tuple[Path, NDArray[np.int32]]):
     path, data = int32_array
-    arr = Array.open(FilesystemStore(str(path)))
+    arr = Array.open(FilesystemStore(path))
     np.testing.assert_array_equal(arr[-1].to_numpy(), data[8:9])
 
 
-def test_ellipsis(int32_array):
+def test_ellipsis(int32_array: tuple[Path, NDArray[np.int32]]):
     path, data = int32_array
-    arr = Array.open(FilesystemStore(str(path)))
+    arr = Array.open(FilesystemStore(path))
     result = arr[5, ..., 3].to_numpy()
     np.testing.assert_array_equal(result, data[5:6, :, 3:4])
 
 
-def test_full_array(int32_array):
+def test_full_array(int32_array: tuple[Path, NDArray[np.int32]]):
     path, data = int32_array
-    arr = Array.open(FilesystemStore(str(path)))
+    arr = Array.open(FilesystemStore(path))
     np.testing.assert_array_equal(arr[...].to_numpy(), data)
 
 
-def test_out_of_bounds_int_raises(int32_array):
+def test_out_of_bounds_int_raises(int32_array: tuple[Path, NDArray[np.int32]]):
     path, _ = int32_array
-    arr = Array.open(FilesystemStore(str(path)))
+    arr = Array.open(FilesystemStore(path))
     with pytest.raises(IndexError):
         arr[9]  # axis 0 has size 9 -> max valid index is 8
 
 
-def test_step_not_one_raises(int32_array):
+def test_step_not_one_raises(int32_array: tuple[Path, NDArray[np.int32]]):
     path, _ = int32_array
-    arr = Array.open(FilesystemStore(str(path)))
+    arr = Array.open(FilesystemStore(path))
     with pytest.raises(NotImplementedError):
         arr[0:9:2]
 
@@ -99,11 +103,11 @@ def test_float64_dtype(tmp_path):
     )
     z[:] = data
 
-    arr = Array.open(FilesystemStore(str(path)))
+    arr = Array.open(FilesystemStore(path))
     np.testing.assert_array_equal(arr[1:3, 0:4].to_numpy(), data[1:3, 0:4])
 
 
-def test_async_getitem_matches_numpy(int32_array):
+def test_async_getitem_matches_numpy(int32_array: tuple[Path, NDArray[np.int32]]):
     """The async path (obstore + `await arr[...]`) returns the same region."""
     path, data = int32_array
 


### PR DESCRIPTION
Previously it always required a cast to str