### PR TITLE
support writable stores

### DIFF
--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -17,16 +17,16 @@ use pyo3_async_runtimes::tokio::future_into_py;
 use pythonize::pythonize;
 use pythonize::Result as PythonizeResult;
 use zarrs::array::Array;
-use zarrs::storage::AsyncReadableListableStorageTraits;
+use zarrs::storage::AsyncReadableWritableListableStorageTraits;
 
-/// A read-only Zarr array.
+/// A Zarr array.
 #[pyclass(module = "zarrista", frozen, name = "AsyncArray")]
 pub struct PyAsyncArray {
-    pub(crate) inner: Arc<Array<dyn AsyncReadableListableStorageTraits>>,
+    pub(crate) inner: Arc<Array<dyn AsyncReadableWritableListableStorageTraits>>,
 }
 
 impl PyAsyncArray {
-    pub(crate) fn new(inner: Arc<Array<dyn AsyncReadableListableStorageTraits>>) -> Self {
+    pub(crate) fn new(inner: Arc<Array<dyn AsyncReadableWritableListableStorageTraits>>) -> Self {
         Self { inner }
     }
 }

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -7,23 +7,23 @@ use crate::data::{for_each_dtype, DataInner, PyData};
 use crate::dtype::PyDataType;
 use crate::error::ZarristaResult;
 use crate::node::PyNodePath;
-use crate::storage::extract_storage;
+use crate::storage::PySyncStorage;
 use ndarray::ArrayD;
 use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::*;
 use pythonize::pythonize;
 use pythonize::Result as PythonizeResult;
 use zarrs::array::Array;
-use zarrs::storage::ReadableListableStorageTraits;
+use zarrs::storage::ReadableWritableListableStorageTraits;
 
-/// A read-only Zarr array.
+/// A Zarr array.
 #[pyclass(module = "zarrista", frozen, name = "Array")]
 pub struct PyArray {
-    pub(crate) inner: Array<dyn ReadableListableStorageTraits>,
+    pub(crate) inner: Array<dyn ReadableWritableListableStorageTraits>,
 }
 
 impl PyArray {
-    pub(crate) fn new(inner: Array<dyn ReadableListableStorageTraits>) -> Self {
+    pub(crate) fn new(inner: Array<dyn ReadableWritableListableStorageTraits>) -> Self {
         Self { inner }
     }
 }
@@ -44,8 +44,8 @@ impl PyArray {
         signature = (store, path = PyNodePath::root()),
         text_signature = "(store, path='/')"
     )]
-    fn open(store: &Bound<'_, PyAny>, path: PyNodePath) -> ZarristaResult<Self> {
-        let storage = extract_storage(store)?;
+    fn open(store: PySyncStorage, path: PyNodePath) -> ZarristaResult<Self> {
+        let storage = store.into();
         let inner = Array::open(storage, path.as_str())?;
         Ok(Self::new(inner))
     }

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -45,8 +45,7 @@ impl PyArray {
         text_signature = "(store, path='/')"
     )]
     fn open(store: PySyncStorage, path: PyNodePath) -> ZarristaResult<Self> {
-        let storage = store.into();
-        let inner = Array::open(storage, path.as_str())?;
+        let inner = Array::open(store.into(), path.as_str())?;
         Ok(Self::new(inner))
     }
 

--- a/src/group/async.rs
+++ b/src/group/async.rs
@@ -10,21 +10,21 @@ use pythonize::pythonize;
 use pythonize::Result as PythonizeResult;
 use zarrs::group::Group;
 use zarrs::node::NodePath;
-use zarrs::storage::AsyncReadableListableStorageTraits;
+use zarrs::storage::AsyncReadableWritableListableStorageTraits;
 
-/// A read-only Zarr group.
+/// A Zarr group.
 #[pyclass(module = "zarrista", frozen, name = "AsyncGroup")]
 pub struct PyAsyncGroup {
-    pub(crate) storage: Arc<dyn AsyncReadableListableStorageTraits>,
+    pub(crate) storage: Arc<dyn AsyncReadableWritableListableStorageTraits>,
     pub(crate) path: NodePath,
-    pub(crate) inner: Arc<Group<dyn AsyncReadableListableStorageTraits>>,
+    pub(crate) inner: Arc<Group<dyn AsyncReadableWritableListableStorageTraits>>,
 }
 
 impl PyAsyncGroup {
     pub(crate) fn new(
-        storage: Arc<dyn AsyncReadableListableStorageTraits>,
+        storage: Arc<dyn AsyncReadableWritableListableStorageTraits>,
         path: NodePath,
-        inner: Arc<Group<dyn AsyncReadableListableStorageTraits>>,
+        inner: Arc<Group<dyn AsyncReadableWritableListableStorageTraits>>,
     ) -> Self {
         Self {
             storage,

--- a/src/group/sync.rs
+++ b/src/group/sync.rs
@@ -5,27 +5,27 @@ use std::sync::Arc;
 use super::last_segment;
 use crate::error::ZarristaResult;
 use crate::node::{open_node, Node, PyNodePath};
-use crate::storage::extract_storage;
+use crate::storage::PySyncStorage;
 use pyo3::prelude::*;
 use pythonize::pythonize;
 use pythonize::Result as PythonizeResult;
 use zarrs::group::Group;
 use zarrs::node::NodePath;
-use zarrs::storage::ReadableListableStorageTraits;
+use zarrs::storage::ReadableWritableListableStorageTraits;
 
-/// A read-only Zarr group.
+/// A Zarr group.
 #[pyclass(module = "zarrista", frozen, name = "Group")]
 pub struct PyGroup {
-    pub(crate) storage: Arc<dyn ReadableListableStorageTraits>,
+    pub(crate) storage: Arc<dyn ReadableWritableListableStorageTraits>,
     pub(crate) path: NodePath,
-    pub(crate) inner: Group<dyn ReadableListableStorageTraits>,
+    pub(crate) inner: Group<dyn ReadableWritableListableStorageTraits>,
 }
 
 impl PyGroup {
     pub(crate) fn new(
-        storage: Arc<dyn ReadableListableStorageTraits>,
+        storage: Arc<dyn ReadableWritableListableStorageTraits>,
         path: NodePath,
-        inner: Group<dyn ReadableListableStorageTraits>,
+        inner: Group<dyn ReadableWritableListableStorageTraits>,
     ) -> Self {
         Self {
             storage,
@@ -43,8 +43,8 @@ impl PyGroup {
         signature = (store, path = PyNodePath::root()),
         text_signature = "(store, path='/')"
     )]
-    fn open(store: &Bound<'_, PyAny>, path: PyNodePath) -> ZarristaResult<Self> {
-        let storage = extract_storage(store)?;
+    fn open(store: PySyncStorage, path: PyNodePath) -> ZarristaResult<Self> {
+        let storage: Arc<dyn ReadableWritableListableStorageTraits> = store.into();
         let inner = Group::open(storage.clone(), path.as_str())?;
         Ok(Self::new(storage, path.into(), inner))
     }

--- a/src/group/sync.rs
+++ b/src/group/sync.rs
@@ -44,9 +44,9 @@ impl PyGroup {
         text_signature = "(store, path='/')"
     )]
     fn open(store: PySyncStorage, path: PyNodePath) -> ZarristaResult<Self> {
-        let storage: Arc<dyn ReadableWritableListableStorageTraits> = store.into();
-        let inner = Group::open(storage.clone(), path.as_str())?;
-        Ok(Self::new(storage, path.into(), inner))
+        let store = store.into_inner();
+        let inner = Group::open(store.clone(), path.as_str())?;
+        Ok(Self::new(store, path.into(), inner))
     }
 
     /// The group's user attributes as a dict.

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -9,7 +9,9 @@ use pyo3::prelude::*;
 use zarrs::array::Array;
 use zarrs::group::Group;
 use zarrs::node::NodePath;
-use zarrs::storage::{AsyncReadableListableStorageTraits, ReadableWritableListableStorageTraits};
+use zarrs::storage::{
+    AsyncReadableWritableListableStorageTraits, ReadableWritableListableStorageTraits,
+};
 
 /// An opened node: either an array or a group.
 #[derive(IntoPyObject)]
@@ -50,7 +52,7 @@ pub(crate) enum AsyncNode {
 /// Returns an [`AsyncNode`] (Python `AsyncArray` or `AsyncGroup`), or raises
 /// `NotFoundError` if neither exists at the path.
 pub(crate) async fn open_node_async(
-    storage: Arc<dyn AsyncReadableListableStorageTraits>,
+    storage: Arc<dyn AsyncReadableWritableListableStorageTraits>,
     path: NodePath,
 ) -> ZarristaResult<AsyncNode> {
     if let Ok(inner) = Array::async_open(storage.clone(), path.as_str()).await {

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -9,7 +9,7 @@ use pyo3::prelude::*;
 use zarrs::array::Array;
 use zarrs::group::Group;
 use zarrs::node::NodePath;
-use zarrs::storage::{AsyncReadableListableStorageTraits, ReadableListableStorageTraits};
+use zarrs::storage::{AsyncReadableListableStorageTraits, ReadableWritableListableStorageTraits};
 
 /// An opened node: either an array or a group.
 #[derive(IntoPyObject)]
@@ -25,7 +25,7 @@ pub(crate) enum Node {
 /// Returns a [`Node`] (Python `Array` or `Group`), or raises `NotFoundError`
 /// if neither exists at the path.
 pub(crate) fn open_node(
-    storage: Arc<dyn ReadableListableStorageTraits>,
+    storage: Arc<dyn ReadableWritableListableStorageTraits>,
     path: NodePath,
 ) -> ZarristaResult<Node> {
     if let Ok(inner) = Array::open(storage.clone(), path.as_str()) {

--- a/src/storage/async.rs
+++ b/src/storage/async.rs
@@ -6,14 +6,14 @@ use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3_bytes::PyBytes;
 use pyo3_object_store::AnyObjectStore;
-use zarrs::storage::AsyncReadableListableStorageTraits;
+use zarrs::storage::AsyncReadableWritableListableStorageTraits;
 use zarrs_icechunk::AsyncIcechunkStore;
 use zarrs_object_store::AsyncObjectStore;
 
-pub struct PyAsyncStorage(Arc<dyn AsyncReadableListableStorageTraits>);
+pub struct PyAsyncStorage(Arc<dyn AsyncReadableWritableListableStorageTraits>);
 
 impl PyAsyncStorage {
-    pub fn into_inner(self) -> Arc<dyn AsyncReadableListableStorageTraits> {
+    pub fn into_inner(self) -> Arc<dyn AsyncReadableWritableListableStorageTraits> {
         self.0
     }
 }
@@ -39,7 +39,7 @@ impl FromPyObject<'_, '_> for PyAsyncStorage {
     }
 }
 
-impl From<PyAsyncStorage> for Arc<dyn AsyncReadableListableStorageTraits> {
+impl From<PyAsyncStorage> for Arc<dyn AsyncReadableWritableListableStorageTraits> {
     fn from(s: PyAsyncStorage) -> Self {
         s.0
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,6 +2,6 @@ mod r#async;
 mod sync;
 
 pub use r#async::PyAsyncStorage;
-pub(crate) use sync::extract_storage;
+pub(crate) use sync::PySyncStorage;
 #[allow(unused)]
-pub use sync::{PyFilesystemStore, PyMemoryStore, SyncStorage};
+pub use sync::{PyFilesystemStore, PyMemoryStore};

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,5 +3,4 @@ mod sync;
 
 pub use r#async::PyAsyncStorage;
 pub(crate) use sync::PySyncStorage;
-#[allow(unused)]
 pub use sync::{PyFilesystemStore, PyMemoryStore};

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -5,21 +5,37 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use zarrs::filesystem::FilesystemStore;
 use zarrs::storage::store::MemoryStore;
-use zarrs::storage::ReadableListableStorageTraits;
+use zarrs::storage::ReadableWritableListableStorageTraits;
 
-use zarrs::storage::{ReadableStorageTraits, ReadableWritableStorageTraits, WritableStorageTraits};
+/// A zarrista sync store object adapted to the maximal `zarrs` storage trait.
+pub struct PySyncStorage(Arc<dyn ReadableWritableListableStorageTraits>);
 
-#[allow(dead_code)]
-pub enum SyncStorage {
-    Readable(Arc<dyn ReadableStorageTraits>),
-    Writable(Arc<dyn WritableStorageTraits>),
-    ReadableWritable(Arc<dyn ReadableWritableStorageTraits>),
+impl FromPyObject<'_, '_> for PySyncStorage {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(s) = obj.cast::<PyFilesystemStore>() {
+            return Ok(Self(s.get().storage.clone()));
+        }
+        if let Ok(s) = obj.cast::<PyMemoryStore>() {
+            return Ok(Self(s.get().storage.clone()));
+        }
+        Err(PyTypeError::new_err(
+            "expected a FilesystemStore or MemoryStore",
+        ))
+    }
+}
+
+impl From<PySyncStorage> for Arc<dyn ReadableWritableListableStorageTraits> {
+    fn from(s: PySyncStorage) -> Self {
+        s.0
+    }
 }
 
 /// A store backed by a local directory.
 #[pyclass(module = "zarrista", frozen, name = "FilesystemStore")]
 pub struct PyFilesystemStore {
-    pub(crate) storage: Arc<dyn ReadableListableStorageTraits>,
+    pub(crate) storage: Arc<dyn ReadableWritableListableStorageTraits>,
 }
 
 #[pymethods]
@@ -41,7 +57,7 @@ impl PyFilesystemStore {
 /// An in-memory store, primarily useful for testing.
 #[pyclass(module = "zarrista", frozen, name = "MemoryStore")]
 pub struct PyMemoryStore {
-    pub(crate) storage: Arc<dyn ReadableListableStorageTraits>,
+    pub(crate) storage: Arc<dyn ReadableWritableListableStorageTraits>,
 }
 
 #[pymethods]
@@ -56,19 +72,4 @@ impl PyMemoryStore {
     fn __repr__(&self) -> String {
         "MemoryStore()".to_string()
     }
-}
-
-/// Pull the inner [`Storage`] out of any zarrista store object.
-pub(crate) fn extract_storage(
-    store: &Bound<'_, PyAny>,
-) -> PyResult<Arc<dyn ReadableListableStorageTraits>> {
-    if let Ok(s) = store.cast::<PyFilesystemStore>() {
-        return Ok(s.get().storage.clone());
-    }
-    if let Ok(s) = store.cast::<PyMemoryStore>() {
-        return Ok(s.get().storage.clone());
-    }
-    Err(PyTypeError::new_err(
-        "expected a FilesystemStore or MemoryStore",
-    ))
 }

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -10,6 +10,12 @@ use zarrs::storage::ReadableWritableListableStorageTraits;
 /// A zarrista sync store object adapted to the maximal `zarrs` storage trait.
 pub struct PySyncStorage(Arc<dyn ReadableWritableListableStorageTraits>);
 
+impl PySyncStorage {
+    pub fn into_inner(self) -> Arc<dyn ReadableWritableListableStorageTraits> {
+        self.0
+    }
+}
+
 impl FromPyObject<'_, '_> for PySyncStorage {
     type Error = PyErr;
 

--- a/tests/test_store_input.py
+++ b/tests/test_store_input.py
@@ -1,0 +1,35 @@
+"""Store input acceptance: built-in stores open; bad objects are rejected.
+
+Verifies that widening the wrapped storage to the writable trait object did not
+change which Python objects `Array.open` / `Group.open` accept.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+from zarrista import Array, FilesystemStore, Group
+
+
+@pytest.fixture
+def array_path(tmp_path: Path) -> Path:
+    """A tiny int32 array written with zarr-python; returns the store path."""
+    path = tmp_path / "a.zarr"
+    z = zarr.create_array(store=str(path), shape=(4,), chunks=(2,), dtype="int32")
+    z[:] = np.arange(4, dtype="int32")
+    return path
+
+
+def test_filesystem_store_opens_and_reads(array_path: Path):
+    array = Array.open(FilesystemStore(str(array_path)))
+    np.testing.assert_array_equal(
+        array.retrieve_chunk([0]).to_numpy(), np.array([0, 1], dtype="int32")
+    )
+
+
+def test_open_rejects_non_store(array_path: Path):
+    with pytest.raises(TypeError, match="FilesystemStore or MemoryStore"):
+        Array.open(object())
+    with pytest.raises(TypeError, match="FilesystemStore or MemoryStore"):
+        Group.open(object())


### PR DESCRIPTION
Precursor support to allow writable stores. This changes the underlying array object to include Writable sync or async traits.