### PR TITLE
Support passing options to `retrieve_array`; add `retrieve_encoded_chunk`

### DIFF
--- a/docs/api/codec.md
+++ b/docs/api/codec.md
@@ -1,3 +1,12 @@
 # CodecChain
 
 ::: zarrista.codec
+
+<!--
+`CodecOptions` is a type-check-only `TypedDict` (it lives in the `.pyi` stubs and
+has no runtime object), so it is not in `zarrista.codec.__all__` and the block
+above does not render it. We render it explicitly so that the
+`[CodecOptions][zarrista.codec.CodecOptions]` cross-references in the array
+read/write docstrings have a target (required under `mkdocs build --strict`).
+-->
+::: zarrista.codec.CodecOptions

--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -1,5 +1,7 @@
 from types import EllipsisType
-from typing import Any
+from typing import Any, Unpack
+
+from zarrista.codec import CodecOptions
 
 from ._chunks import ChunkGrid
 from ._codec import CodecChain
@@ -47,14 +49,23 @@ class Array:
     @property
     def path(self) -> str:
         """The array's path in the store."""
-    def retrieve_array_subset(self, selection: Selection) -> Data:
+    def retrieve_array_subset(
+        self, selection: Selection, **kwargs: Unpack[CodecOptions]
+    ) -> Data:
         """Read and decode an array region selected with numpy-style basic indexing.
 
         The result is ndim-preserving (consistent with a zarrs `ArraySubset`): an
         integer selects a length-1 range and that axis is retained.
+
+        Keyword arguments are passed as [`CodecOptions`][zarrista.codec.CodecOptions].
         """
-    def retrieve_chunk(self, chunk_indices: list[int]) -> Data:
-        """Read and decode the chunk at the given chunk grid indices."""
+    def retrieve_chunk(
+        self, chunk_indices: list[int], **kwargs: Unpack[CodecOptions]
+    ) -> Data:
+        """Read and decode the chunk at the given chunk grid indices.
+
+        Keyword arguments are passed as [`CodecOptions`][zarrista.codec.CodecOptions].
+        """
     @property
     def shape(self) -> list[int]:
         """The array shape."""
@@ -98,14 +109,23 @@ class AsyncArray:
     @property
     def path(self) -> str:
         """The array's path in the store."""
-    async def retrieve_array_subset(self, selection: Selection) -> Data:
+    async def retrieve_array_subset(
+        self, selection: Selection, **kwargs: Unpack[CodecOptions]
+    ) -> Data:
         """Read and decode an array region selected with numpy-style basic indexing.
 
         The result is ndim-preserving (consistent with a zarrs `ArraySubset`): an
         integer selects a length-1 range and that axis is retained.
+
+        Keyword arguments are passed as [`CodecOptions`][zarrista.codec.CodecOptions].
         """
-    async def retrieve_chunk(self, chunk_indices: list[int]) -> Data:
-        """Read and decode the chunk at the given chunk grid indices."""
+    async def retrieve_chunk(
+        self, chunk_indices: list[int], **kwargs: Unpack[CodecOptions]
+    ) -> Data:
+        """Read and decode the chunk at the given chunk grid indices.
+
+        Keyword arguments are passed as [`CodecOptions`][zarrista.codec.CodecOptions].
+        """
     @property
     def shape(self) -> list[int]:
         """The array shape."""

--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -50,7 +50,7 @@ class Array:
     def path(self) -> str:
         """The array's path in the store."""
     def retrieve_array_subset(
-        self, selection: Selection, **kwargs: Unpack[CodecOptions]
+        self, selection: Selection, **codec_options: Unpack[CodecOptions]
     ) -> Data:
         """Read and decode an array region selected with numpy-style basic indexing.
 
@@ -60,7 +60,7 @@ class Array:
         Keyword arguments are passed as [`CodecOptions`][zarrista.codec.CodecOptions].
         """
     def retrieve_chunk(
-        self, chunk_indices: list[int], **kwargs: Unpack[CodecOptions]
+        self, chunk_indices: list[int], **codec_options: Unpack[CodecOptions]
     ) -> Data:
         """Read and decode the chunk at the given chunk grid indices.
 
@@ -110,7 +110,7 @@ class AsyncArray:
     def path(self) -> str:
         """The array's path in the store."""
     async def retrieve_array_subset(
-        self, selection: Selection, **kwargs: Unpack[CodecOptions]
+        self, selection: Selection, **codec_options: Unpack[CodecOptions]
     ) -> Data:
         """Read and decode an array region selected with numpy-style basic indexing.
 
@@ -120,7 +120,7 @@ class AsyncArray:
         Keyword arguments are passed as [`CodecOptions`][zarrista.codec.CodecOptions].
         """
     async def retrieve_chunk(
-        self, chunk_indices: list[int], **kwargs: Unpack[CodecOptions]
+        self, chunk_indices: list[int], **codec_options: Unpack[CodecOptions]
     ) -> Data:
         """Read and decode the chunk at the given chunk grid indices.
 

--- a/python/zarrista/codec/__init__.pyi
+++ b/python/zarrista/codec/__init__.pyi
@@ -7,3 +7,4 @@ from zarrista.codec._bytes_to_bytes._crc32c import Crc32c as Crc32c
 from zarrista.codec._bytes_to_bytes._gzip import Gzip as Gzip
 from zarrista.codec._bytes_to_bytes._zstd import Zstd as Zstd
 from zarrista.codec._codec_chain import CodecChain as CodecChain
+from zarrista.codec._options import CodecOptions as CodecOptions

--- a/python/zarrista/codec/_options.pyi
+++ b/python/zarrista/codec/_options.pyi
@@ -1,0 +1,40 @@
+from typing import TypedDict
+
+class CodecOptions(TypedDict, total=False):
+    """Per-operation codec options for encoding and decoding.
+
+    These control runtime behaviour such as concurrency limits and checksum
+    validation. They are passed as keyword arguments to the array read/write
+    methods, e.g. `arr.retrieve_chunk([0, 0], validate_checksums=False)`. All
+    keys are optional; omitted keys fall back to the defaults noted below.
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING`
+        block:
+
+        ```py
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from zarrista.codec import CodecOptions
+        ```
+    """
+
+    validate_checksums: bool
+    """Whether to validate checksums when decoding. Defaults to `True`."""
+
+    store_empty_chunks: bool
+    """Whether to store chunks that are entirely the fill value. Defaults to `False`."""
+
+    concurrent_target: int
+    """Preferred number of concurrent operations. Defaults to the number of
+    threads available to Rayon."""
+
+    chunk_concurrent_minimum: int
+    """Preferred minimum chunk concurrency for multi-chunk operations. The
+    concurrency of internal codecs is adjusted to accommodate the chunk
+    concurrency in accordance with `concurrent_target`. Defaults to `4`."""
+
+    experimental_partial_encoding: bool
+    """Whether to use experimental partial encoding. Defaults to `False`."""

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use crate::array::selection::PySelection;
+use crate::array::util::PyChunkIndices;
 use crate::chunks::PyChunkGrid;
 use crate::codec::PyCodecChain;
 use crate::data::{for_each_dtype, DataInner, PyData};
@@ -14,6 +15,7 @@ use ndarray::ArrayD;
 use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::*;
 use pyo3_async_runtimes::tokio::future_into_py;
+use pyo3_bytes::PyBytes;
 use pythonize::pythonize;
 use pythonize::Result as PythonizeResult;
 use zarrs::array::Array;
@@ -33,6 +35,15 @@ impl PyAsyncArray {
 
 #[pymethods]
 impl PyAsyncArray {
+    /// Read a region with numpy-style basic indexing, e.g. `await arr[0:10, :, 5]`.
+    fn __getitem__<'py>(
+        &self,
+        py: Python<'py>,
+        selection: PySelection,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        self.retrieve_array_subset(py, selection)
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "AsyncArray(shape={:?}, dtype={:?})",
@@ -139,19 +150,10 @@ impl PyAsyncArray {
         })
     }
 
-    /// Read a region with numpy-style basic indexing, e.g. `await arr[0:10, :, 5]`.
-    fn __getitem__<'py>(
-        &self,
-        py: Python<'py>,
-        selection: PySelection,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        self.retrieve_array_subset(py, selection)
-    }
-
     fn retrieve_chunk<'py>(
         &self,
         py: Python<'py>,
-        chunk_indices: Vec<u64>,
+        chunk_indices: PyChunkIndices,
     ) -> PyResult<Bound<'py, PyAny>> {
         use zarrs::array::data_type::*;
 
@@ -164,7 +166,7 @@ impl PyAsyncArray {
                 ($dtype:ty, $variant:ident, $elem:ty) => {
                     if dtype.is::<$dtype>() {
                         let chunk = inner
-                            .async_retrieve_chunk::<ArrayD<$elem>>(&chunk_indices)
+                            .async_retrieve_chunk::<ArrayD<$elem>>(chunk_indices.as_ref())
                             .await
                             .map_err(ZarristaError::from)?;
                         return Ok(PyData::from(DataInner::$variant(chunk)));
@@ -176,6 +178,21 @@ impl PyAsyncArray {
             Err(PyNotImplementedError::new_err(format!(
                 "reading data type {dtype} is not supported yet"
             )))
+        })
+    }
+
+    fn retrieve_encoded_chunk<'py>(
+        &self,
+        py: Python<'py>,
+        chunk_indices: PyChunkIndices,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        future_into_py(py, async move {
+            let encoded = inner
+                .async_retrieve_encoded_chunk(chunk_indices.as_ref())
+                .await
+                .map_err(ZarristaError::from)?;
+            Ok(encoded.map(PyBytes::new))
         })
     }
 

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::array::selection::PySelection;
 use crate::array::util::PyChunkIndices;
 use crate::chunks::PyChunkGrid;
-use crate::codec::PyCodecChain;
+use crate::codec::{PyCodecChain, PyCodecOptions};
 use crate::data::{for_each_dtype, DataInner, PyData};
 use crate::dtype::PyDataType;
 use crate::error::ZarristaError;
@@ -150,14 +150,19 @@ impl PyAsyncArray {
         })
     }
 
+    #[pyo3(signature = (chunk_indices, **codec_options))]
     fn retrieve_chunk<'py>(
         &self,
         py: Python<'py>,
         chunk_indices: PyChunkIndices,
+        codec_options: Option<PyCodecOptions>,
     ) -> PyResult<Bound<'py, PyAny>> {
         use zarrs::array::data_type::*;
 
         let inner = self.inner.clone();
+        let codec_options = codec_options
+            .map(|opts| opts.into_inner())
+            .unwrap_or_default();
 
         future_into_py(py, async move {
             let dtype = inner.data_type();
@@ -166,7 +171,10 @@ impl PyAsyncArray {
                 ($dtype:ty, $variant:ident, $elem:ty) => {
                     if dtype.is::<$dtype>() {
                         let chunk = inner
-                            .async_retrieve_chunk::<ArrayD<$elem>>(chunk_indices.as_ref())
+                            .async_retrieve_chunk_opt::<ArrayD<$elem>>(
+                                chunk_indices.as_ref(),
+                                &codec_options,
+                            )
                             .await
                             .map_err(ZarristaError::from)?;
                         return Ok(PyData::from(DataInner::$variant(chunk)));

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -1,6 +1,7 @@
 mod r#async;
 mod selection;
 mod sync;
+mod util;
 
 pub use r#async::PyAsyncArray;
 pub use sync::PyArray;

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -1,6 +1,7 @@
 //! The `Array` Python class: metadata accessors and numpy-style reads.
 
 use crate::array::selection::PySelection;
+use crate::array::util::PyChunkIndices;
 use crate::chunks::PyChunkGrid;
 use crate::codec::PyCodecChain;
 use crate::data::{for_each_dtype, DataInner, PyData};
@@ -11,6 +12,7 @@ use crate::storage::PySyncStorage;
 use ndarray::ArrayD;
 use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::*;
+use pyo3_bytes::PyBytes;
 use pythonize::pythonize;
 use pythonize::Result as PythonizeResult;
 use zarrs::array::Array;
@@ -30,6 +32,11 @@ impl PyArray {
 
 #[pymethods]
 impl PyArray {
+    /// Read a region with numpy-style basic indexing, e.g. `arr[0:10, :, 5]`.
+    fn __getitem__(&self, selection: PySelection) -> ZarristaResult<PyData> {
+        self.retrieve_array_subset(selection)
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "Array(shape={:?}, dtype={:?})",
@@ -119,12 +126,7 @@ impl PyArray {
         .into())
     }
 
-    /// Read a region with numpy-style basic indexing, e.g. `arr[0:10, :, 5]`.
-    fn __getitem__(&self, selection: PySelection) -> ZarristaResult<PyData> {
-        self.retrieve_array_subset(selection)
-    }
-
-    fn retrieve_chunk(&self, chunk_indices: Vec<u64>) -> ZarristaResult<PyData> {
+    fn retrieve_chunk(&self, chunk_indices: PyChunkIndices) -> ZarristaResult<PyData> {
         use zarrs::array::data_type::*;
 
         let dtype = self.inner.data_type();
@@ -132,7 +134,9 @@ impl PyArray {
         macro_rules! arm {
             ($dtype:ty, $variant:ident, $elem:ty) => {
                 if dtype.is::<$dtype>() {
-                    let chunk = self.inner.retrieve_chunk::<ArrayD<$elem>>(&chunk_indices)?;
+                    let chunk = self
+                        .inner
+                        .retrieve_chunk::<ArrayD<$elem>>(chunk_indices.as_ref())?;
                     return Ok(PyData::from(DataInner::$variant(chunk)));
                 }
             };
@@ -143,6 +147,14 @@ impl PyArray {
             "reading data type {dtype} is not supported yet"
         ))
         .into())
+    }
+
+    fn retrieve_encoded_chunk(
+        &self,
+        chunk_indices: PyChunkIndices,
+    ) -> ZarristaResult<Option<PyBytes>> {
+        let encoded = self.inner.retrieve_encoded_chunk(chunk_indices.as_ref())?;
+        Ok(encoded.map(|buf| PyBytes::new(buf.into())))
     }
 
     /// The array shape.

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -3,7 +3,7 @@
 use crate::array::selection::PySelection;
 use crate::array::util::PyChunkIndices;
 use crate::chunks::PyChunkGrid;
-use crate::codec::PyCodecChain;
+use crate::codec::{PyCodecChain, PyCodecOptions};
 use crate::data::{for_each_dtype, DataInner, PyData};
 use crate::dtype::PyDataType;
 use crate::error::ZarristaResult;
@@ -126,17 +126,26 @@ impl PyArray {
         .into())
     }
 
-    fn retrieve_chunk(&self, chunk_indices: PyChunkIndices) -> ZarristaResult<PyData> {
+    #[pyo3(signature = (chunk_indices, **codec_options))]
+    fn retrieve_chunk(
+        &self,
+        chunk_indices: PyChunkIndices,
+        codec_options: Option<PyCodecOptions>,
+    ) -> ZarristaResult<PyData> {
         use zarrs::array::data_type::*;
 
         let dtype = self.inner.data_type();
+        let codec_options = codec_options
+            .map(|opts| opts.into_inner())
+            .unwrap_or_default();
 
         macro_rules! arm {
             ($dtype:ty, $variant:ident, $elem:ty) => {
                 if dtype.is::<$dtype>() {
-                    let chunk = self
-                        .inner
-                        .retrieve_chunk::<ArrayD<$elem>>(chunk_indices.as_ref())?;
+                    let chunk = self.inner.retrieve_chunk_opt::<ArrayD<$elem>>(
+                        chunk_indices.as_ref(),
+                        &codec_options,
+                    )?;
                     return Ok(PyData::from(DataInner::$variant(chunk)));
                 }
             };

--- a/src/array/util.rs
+++ b/src/array/util.rs
@@ -1,0 +1,10 @@
+use pyo3::prelude::*;
+
+#[derive(IntoPyObject, FromPyObject, Clone, Debug)]
+pub struct PyChunkIndices(Vec<u64>);
+
+impl AsRef<[u64]> for PyChunkIndices {
+    fn as_ref(&self) -> &[u64] {
+        &self.0
+    }
+}

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,6 +1,7 @@
 mod array_to_array;
 mod bytes_to_bytes;
 mod codec_chain;
+mod options;
 
 use pyo3::prelude::*;
 
@@ -11,6 +12,7 @@ pub use bytes_to_bytes::gzip::PyGzip;
 pub use bytes_to_bytes::zstd::PyZstd;
 pub use bytes_to_bytes::PyBytesToBytesCodec;
 pub use codec_chain::PyCodecChain;
+pub use options::PyCodecOptions;
 
 /// Build the `zarrista.codec` submodule and attach it to `parent`.
 ///

--- a/src/codec/options.rs
+++ b/src/codec/options.rs
@@ -1,0 +1,62 @@
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedStr;
+use pyo3::types::{PyMapping, PyMappingMethods};
+use pyo3::{Borrowed, FromPyObject};
+use zarrs::array::CodecOptions;
+
+/// Per-operation [`CodecOptions`], extractable from any mapping
+#[derive(Debug, Clone, Default)]
+pub struct PyCodecOptions(CodecOptions);
+
+impl PyCodecOptions {
+    pub fn into_inner(self) -> CodecOptions {
+        self.0
+    }
+}
+
+impl AsRef<CodecOptions> for PyCodecOptions {
+    fn as_ref(&self) -> &CodecOptions {
+        &self.0
+    }
+}
+
+impl From<PyCodecOptions> for CodecOptions {
+    fn from(options: PyCodecOptions) -> Self {
+        options.0
+    }
+}
+
+impl FromPyObject<'_, '_> for PyCodecOptions {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
+        let mut options = CodecOptions::default();
+        for item in obj.cast::<PyMapping>()?.items()?.iter() {
+            let (key, value) = item.extract::<(PyBackedStr, Bound<'_, PyAny>)>()?;
+            match &*key {
+                "validate_checksums" => {
+                    options.set_validate_checksums(value.extract()?);
+                }
+                "store_empty_chunks" => {
+                    options.set_store_empty_chunks(value.extract()?);
+                }
+                "concurrent_target" => {
+                    options.set_concurrent_target(value.extract()?);
+                }
+                "chunk_concurrent_minimum" => {
+                    options.set_chunk_concurrent_minimum(value.extract()?);
+                }
+                "experimental_partial_encoding" => {
+                    options.set_experimental_partial_encoding(value.extract()?);
+                }
+                other => {
+                    return Err(PyTypeError::new_err(format!(
+                        "unexpected keyword argument {other:?}"
+                    )));
+                }
+            }
+        }
+        Ok(Self(options))
+    }
+}


### PR DESCRIPTION
### Change list

- Define `CodecOptions` as a Rust options struct with `FromPyOptions` and as a Python TypedDict
- Expose codec options to `retrieve_array`
- Add `retrieve_encoded_chunk` method