### PR TITLE
feat: Add DLPack support for `Tensor` class

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlpark"
+version = "0.7.0"
+source = "git+https://github.com/kylebarron/dlpark?rev=31c6f49c064e634326c97172d39a00acecd854b6#31c6f49c064e634326c97172d39a00acecd854b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "snafu",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3795,6 +3804,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "snafu"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4935,6 +4965,7 @@ name = "zarrista"
 version = "0.1.0-beta.2"
 dependencies = [
  "bytes",
+ "dlpark",
  "half",
  "icechunk",
  "ndarray",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ version = "0.7.0"
 source = "git+https://github.com/kylebarron/dlpark?rev=31c6f49c064e634326c97172d39a00acecd854b6#31c6f49c064e634326c97172d39a00acecd854b6"
 dependencies = [
  "bitflags 2.13.0",
+ "pyo3",
  "snafu",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ abi3-py311 = ["pyo3/abi3-py311"]
 
 [dependencies]
 bytes = "1.12.0"
+dlpark = { git = "https://github.com/kylebarron/dlpark", rev = "31c6f49c064e634326c97172d39a00acecd854b6" }
 half = "2"
 icechunk = "2.0.0"
 ndarray = "0.17.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ abi3-py311 = ["pyo3/abi3-py311"]
 
 [dependencies]
 bytes = "1.12.0"
-dlpark = { git = "https://github.com/kylebarron/dlpark", rev = "31c6f49c064e634326c97172d39a00acecd854b6" }
+dlpark = { git = "https://github.com/kylebarron/dlpark", rev = "31c6f49c064e634326c97172d39a00acecd854b6", features = [
+    "pyo3",
+] }
 half = "2"
 icechunk = "2.0.0"
 ndarray = "0.17.2"

--- a/python/zarrista/_decoded_array.pyi
+++ b/python/zarrista/_decoded_array.pyi
@@ -10,6 +10,11 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import Buffer
 
+if sys.version_info >= (3, 13):
+    from types import CapsuleType
+else:
+    from typing_extensions import CapsuleType
+
 class Tensor:
     """Fixed-width, dense decoded array data.
 
@@ -30,6 +35,17 @@ class Tensor:
 
         This is a zero-copy view via `np.frombuffer`.
         """
+    def __dlpack__(
+        self,
+        *,
+        stream: int | None = None,
+        max_version: tuple[int, int] | None = None,
+        dl_device: tuple[int, int] | None = None,
+        copy: bool | None = None,
+    ) -> CapsuleType:
+        """Export the data as a DLPack capsule (e.g. for `np.from_dlpack`)."""
+    def __dlpack_device__(self) -> tuple[int, int]:
+        """Return the DLPack device `(device_type, device_id)`. Always CPU."""
 
 class VariableArray:
     """Variable-length decoded data (e.g. strings or bytes).

--- a/src/decoded_array.rs
+++ b/src/decoded_array.rs
@@ -25,11 +25,11 @@ use std::ffi::c_void;
 use bytes::Bytes;
 use dlpark::ffi::Device;
 use dlpark::traits::{RowMajorCompactLayout, TensorLike};
-use pyo3::exceptions::PyNotImplementedError;
+use pyo3::exceptions::{PyNotImplementedError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use pyo3_bytes::PyBytes;
-use zarrs::array::{ArrayBytes, ArrayError, DataType, FromArrayBytes, TensorError};
+use zarrs::array::{ArrayBytes, ArrayError, DataType, FromArrayBytes};
 
 use crate::dtype::PyDataType;
 use crate::error::{ZarristaError, ZarristaResult};
@@ -88,36 +88,34 @@ impl PyTensor {
 fn data_type_to_dlpack(data_type: &DataType) -> ZarristaResult<dlpark::ffi::DataType> {
     use zarrs::array::data_type::*;
 
-    let type_id = data_type.as_any().type_id();
-    // https://github.com/rust-lang/rust/issues/70861 for match?
-    if type_id == TypeId::of::<BoolDataType>() {
+    if data_type.is::<BoolDataType>() {
         Ok(dlpark::ffi::DataType::BOOL)
-    } else if type_id == TypeId::of::<Int8DataType>() {
+    } else if data_type.is::<Int8DataType>() {
         Ok(dlpark::ffi::DataType::I8)
-    } else if type_id == TypeId::of::<Int16DataType>() {
+    } else if data_type.is::<Int16DataType>() {
         Ok(dlpark::ffi::DataType::I16)
-    } else if type_id == TypeId::of::<Int32DataType>() {
+    } else if data_type.is::<Int32DataType>() {
         Ok(dlpark::ffi::DataType::I32)
-    } else if type_id == TypeId::of::<Int64DataType>() {
+    } else if data_type.is::<Int64DataType>() {
         Ok(dlpark::ffi::DataType::I64)
-    } else if type_id == TypeId::of::<UInt8DataType>() {
+    } else if data_type.is::<UInt8DataType>() {
         Ok(dlpark::ffi::DataType::U8)
-    } else if type_id == TypeId::of::<UInt16DataType>() {
+    } else if data_type.is::<UInt16DataType>() {
         Ok(dlpark::ffi::DataType::U16)
-    } else if type_id == TypeId::of::<UInt32DataType>() {
+    } else if data_type.is::<UInt32DataType>() {
         Ok(dlpark::ffi::DataType::U32)
-    } else if type_id == TypeId::of::<UInt64DataType>() {
+    } else if data_type.is::<UInt64DataType>() {
         Ok(dlpark::ffi::DataType::U64)
-    } else if type_id == TypeId::of::<Float16DataType>() {
+    } else if data_type.is::<Float16DataType>() {
         Ok(dlpark::ffi::DataType::F16)
-    } else if type_id == TypeId::of::<Float32DataType>() {
+    } else if data_type.is::<Float32DataType>() {
         Ok(dlpark::ffi::DataType::F32)
-    } else if type_id == TypeId::of::<Float64DataType>() {
+    } else if data_type.is::<Float64DataType>() {
         Ok(dlpark::ffi::DataType::F64)
-    } else if type_id == TypeId::of::<BFloat16DataType>() {
+    } else if data_type.is::<BFloat16DataType>() {
         Ok(dlpark::ffi::DataType::BF16)
     } else {
-        Err(TensorError::UnsupportedDataType(data_type.clone())).map_err(ZarristaError::from)
+        Err(PyValueError::new_err("Unsupported data type in dlpack").into())
     }
 }
 

--- a/src/decoded_array.rs
+++ b/src/decoded_array.rs
@@ -20,15 +20,19 @@
 //! pays the alignment copy as part of the copy it was already doing.
 
 use std::borrow::Cow;
+use std::ffi::c_void;
 
 use bytes::Bytes;
+use dlpark::ffi::Device;
+use dlpark::traits::{RowMajorCompactLayout, TensorLike};
 use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use pyo3_bytes::PyBytes;
-use zarrs::array::{ArrayBytes, ArrayError, DataType, FromArrayBytes};
+use zarrs::array::{ArrayBytes, ArrayError, DataType, FromArrayBytes, TensorError};
 
 use crate::dtype::PyDataType;
+use crate::error::{ZarristaError, ZarristaResult};
 
 /// Fixed-width, dense decoded data.
 ///
@@ -74,6 +78,75 @@ impl PyTensor {
         let np = py.import("numpy")?;
         let flat = np.call_method1("frombuffer", (self.buffer(), name.into_owned()))?;
         flat.call_method1("reshape", (&self.shape,))
+    }
+}
+
+/// Convert a zarrs [`DataType`] to a [`dlpark::ffi::DataType`].
+///
+/// # Errors
+/// Returns [`TensorError::UnsupportedDataType`] if the data type is not supported.
+fn data_type_to_dlpack(data_type: &DataType) -> ZarristaResult<dlpark::ffi::DataType> {
+    use zarrs::array::data_type::*;
+
+    let type_id = data_type.as_any().type_id();
+    // https://github.com/rust-lang/rust/issues/70861 for match?
+    if type_id == TypeId::of::<BoolDataType>() {
+        Ok(dlpark::ffi::DataType::BOOL)
+    } else if type_id == TypeId::of::<Int8DataType>() {
+        Ok(dlpark::ffi::DataType::I8)
+    } else if type_id == TypeId::of::<Int16DataType>() {
+        Ok(dlpark::ffi::DataType::I16)
+    } else if type_id == TypeId::of::<Int32DataType>() {
+        Ok(dlpark::ffi::DataType::I32)
+    } else if type_id == TypeId::of::<Int64DataType>() {
+        Ok(dlpark::ffi::DataType::I64)
+    } else if type_id == TypeId::of::<UInt8DataType>() {
+        Ok(dlpark::ffi::DataType::U8)
+    } else if type_id == TypeId::of::<UInt16DataType>() {
+        Ok(dlpark::ffi::DataType::U16)
+    } else if type_id == TypeId::of::<UInt32DataType>() {
+        Ok(dlpark::ffi::DataType::U32)
+    } else if type_id == TypeId::of::<UInt64DataType>() {
+        Ok(dlpark::ffi::DataType::U64)
+    } else if type_id == TypeId::of::<Float16DataType>() {
+        Ok(dlpark::ffi::DataType::F16)
+    } else if type_id == TypeId::of::<Float32DataType>() {
+        Ok(dlpark::ffi::DataType::F32)
+    } else if type_id == TypeId::of::<Float64DataType>() {
+        Ok(dlpark::ffi::DataType::F64)
+    } else if type_id == TypeId::of::<BFloat16DataType>() {
+        Ok(dlpark::ffi::DataType::BF16)
+    } else {
+        Err(TensorError::UnsupportedDataType(data_type.clone())).map_err(ZarristaError::from)
+    }
+}
+
+impl TensorLike<RowMajorCompactLayout> for PyTensor {
+    type Error = ZarristaError;
+
+    fn data_ptr(&self) -> *mut c_void {
+        self.bytes.as_ptr().cast::<c_void>().cast_mut()
+    }
+
+    fn memory_layout(&self) -> RowMajorCompactLayout {
+        let shape = self
+            .shape()
+            .iter()
+            .map(|s| i64::try_from(*s).expect("overflow converting shape to i64"))
+            .collect();
+        RowMajorCompactLayout::new(shape)
+    }
+
+    fn byte_offset(&self) -> u64 {
+        0
+    }
+
+    fn device(&self) -> Result<Device, Self::Error> {
+        Ok(Device::CPU)
+    }
+
+    fn data_type(&self) -> Result<dlpark::ffi::DataType, Self::Error> {
+        data_type_to_dlpack(&self.data_type)
     }
 }
 

--- a/src/decoded_array.rs
+++ b/src/decoded_array.rs
@@ -23,10 +23,12 @@ use std::borrow::Cow;
 use std::ffi::c_void;
 
 use bytes::Bytes;
-use dlpark::ffi::Device;
+use dlpark::ffi::{Device, DeviceType};
 use dlpark::traits::{RowMajorCompactLayout, TensorLike};
+use dlpark::SafeManagedTensor;
 use pyo3::exceptions::{PyNotImplementedError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use pyo3::IntoPyObjectExt;
 use pyo3_bytes::PyBytes;
 use zarrs::array::{ArrayBytes, ArrayError, DataType, FromArrayBytes};
@@ -38,7 +40,8 @@ use crate::error::{ZarristaError, ZarristaResult};
 ///
 /// We don't use the upstream `Tensor` type because its bytes are not reference counted, and thus
 /// don't play nicely with buffer protocol export
-#[pyclass(module = "zarrista", frozen, name = "Tensor")]
+#[derive(Clone)]
+#[pyclass(module = "zarrista", frozen, name = "Tensor", skip_from_py_object)]
 pub struct PyTensor {
     bytes: Bytes,
     data_type: DataType,
@@ -78,6 +81,21 @@ impl PyTensor {
         let np = py.import("numpy")?;
         let flat = np.call_method1("frombuffer", (self.buffer(), name.into_owned()))?;
         flat.call_method1("reshape", (&self.shape,))
+    }
+
+    /// Export via the DLPack protocol so consumers (e.g. `np.from_dlpack`) can
+    /// import this data zero-copy.
+    #[pyo3(signature = (**_kwargs))]
+    fn __dlpack__<'py>(
+        &self,
+        _kwargs: Option<Bound<'py, PyDict>>,
+    ) -> ZarristaResult<SafeManagedTensor> {
+        SafeManagedTensor::new(self.clone())
+    }
+
+    /// The DLPack device this data lives on: `(device_type, device_id)`. Always CPU.
+    fn __dlpack_device__(&self) -> (i32, i32) {
+        (DeviceType::Cpu as i32, 0)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,12 +6,11 @@
 //! [`ZarristaResult`] can therefore use `?` directly on those underlying
 //! errors instead of sprinkling `.map_err(...)` everywhere.
 
-use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::*;
 use pythonize::PythonizeError;
 use thiserror::Error;
 use zarrs::array::codec::TransposeOrderError;
-use zarrs::array::{ArrayCreateError, ArrayError, CodecError, TensorError};
+use zarrs::array::{ArrayCreateError, ArrayError, CodecError};
 use zarrs::filesystem::FilesystemStoreCreateError;
 use zarrs::group::GroupCreateError;
 use zarrs::node::{NodeCreateError, NodePathError};
@@ -71,9 +70,6 @@ pub enum ZarristaError {
     /// Failed to create a codec (or other plugin) from its configuration.
     #[error(transparent)]
     PluginCreate(#[from] PluginCreateError),
-    /// A data type unsupported by a tensor export (e.g. DLPack).
-    #[error(transparent)]
-    Tensor(#[from] TensorError),
 }
 
 impl ZarristaError {
@@ -104,7 +100,6 @@ impl From<ZarristaError> for PyErr {
                 exc::TransposeOrderError::new_err(err.to_string())
             }
             ZarristaError::PluginCreate(err) => exc::PluginCreateError::new_err(err.to_string()),
-            ZarristaError::Tensor(err) => PyNotImplementedError::new_err(err.to_string()),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,11 +6,12 @@
 //! [`ZarristaResult`] can therefore use `?` directly on those underlying
 //! errors instead of sprinkling `.map_err(...)` everywhere.
 
+use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::*;
 use pythonize::PythonizeError;
 use thiserror::Error;
 use zarrs::array::codec::TransposeOrderError;
-use zarrs::array::{ArrayCreateError, ArrayError, CodecError};
+use zarrs::array::{ArrayCreateError, ArrayError, CodecError, TensorError};
 use zarrs::filesystem::FilesystemStoreCreateError;
 use zarrs::group::GroupCreateError;
 use zarrs::node::{NodeCreateError, NodePathError};
@@ -27,7 +28,7 @@ use crate::exceptions as exc;
 /// appropriate Python exception.
 #[derive(Debug, Error)]
 #[non_exhaustive]
-pub(crate) enum ZarristaError {
+pub enum ZarristaError {
     /// No array or group exists at the requested path.
     #[error("{0}")]
     NotFound(String),
@@ -70,6 +71,9 @@ pub(crate) enum ZarristaError {
     /// Failed to create a codec (or other plugin) from its configuration.
     #[error(transparent)]
     PluginCreate(#[from] PluginCreateError),
+    /// A data type unsupported by a tensor export (e.g. DLPack).
+    #[error(transparent)]
+    Tensor(#[from] TensorError),
 }
 
 impl ZarristaError {
@@ -100,6 +104,7 @@ impl From<ZarristaError> for PyErr {
                 exc::TransposeOrderError::new_err(err.to_string())
             }
             ZarristaError::PluginCreate(err) => exc::PluginCreateError::new_err(err.to_string()),
+            ZarristaError::Tensor(err) => PyNotImplementedError::new_err(err.to_string()),
         }
     }
 }

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -57,6 +57,25 @@ def test_fixed_dtype_returns_tensor(int32_array: tuple[Path, NDArray[np.int32]])
     np.testing.assert_array_equal(from_buffer, expected)
 
 
+def test_dlpack_roundtrips(int32_array: tuple[Path, NDArray[np.int32]]):
+    """A `Tensor` exports via DLPack; `np.from_dlpack` yields the same N-D array.
+
+    Unlike the buffer-protocol path, DLPack carries the shape natively, so the
+    result is already N-D (no reshape needed)."""
+    path, data = int32_array
+    arr = Array.open(FilesystemStore(path))
+
+    tensor = arr.retrieve_array_subset((slice(0, 2), slice(None), slice(5, 7)))
+    assert isinstance(tensor, Tensor)
+
+    result = np.from_dlpack(tensor)
+    expected = data[0:2, :, 5:7]
+    assert result.shape == expected.shape
+    assert result.dtype == data.dtype
+    np.testing.assert_array_equal(result, expected)
+    np.testing.assert_array_equal(result, tensor.to_numpy())
+
+
 def test_getitem_matches_retrieve_array_subset(
     int32_array: tuple[Path, NDArray[np.int32]],
 ):


### PR DESCRIPTION
This uses [dlpark](https://github.com/SunDoge/dlpark/) to expose array data via the [DLPack](https://github.com/dmlc/dlpack) interface. This is a zero-copy data interface for ND data, much like Arrow is for tabular data.

Zarrs has native dlpark integration, but zarrs is pinned to an old version of dlpark, which is in turn pinned to an old version of `pyo3`. We use a branch on my fork to pin to https://github.com/SunDoge/dlpark/pull/47, which uses `pyo3` 0.29