### PR TITLE
feat: Add `DataType.from_name` constructor

### DIFF
--- a/python/zarrista/__init__.py
+++ b/python/zarrista/__init__.py
@@ -48,10 +48,6 @@ DataTypeName: TypeAlias = Literal[
     "bytes",
 ]
 """The Zarr v3 names of the built-in fixed data types.
-
-Documents the common names for editor autocompletion; arbitrary strings (e.g.
-raw `"r*"` types or extension data types) are still accepted by
-`DataType.from_string`.
 """
 
 

--- a/python/zarrista/__init__.py
+++ b/python/zarrista/__init__.py
@@ -1,6 +1,6 @@
 """A low-level Zarr API for Python, binding to Rust's Zarrs."""
 
-from typing import TypeAlias
+from typing import Any, Literal, TypeAlias
 
 from . import codec, exceptions
 from ._zarrista import (
@@ -29,6 +29,41 @@ whether it carries a validity mask). Use `isinstance` to narrow to a concrete
 type before using layout-specific methods.
 """
 
+DataTypeName: TypeAlias = Literal[
+    "bool",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "float16",
+    "float32",
+    "float64",
+    "complex64",
+    "complex128",
+    "string",
+    "bytes",
+]
+"""The Zarr v3 names of the built-in fixed data types.
+
+Documents the common names for editor autocompletion; arbitrary strings (e.g.
+raw `"r*"` types or extension data types) are still accepted via `str` in
+`DataTypeInput`.
+"""
+
+DataTypeInput: TypeAlias = DataType | DataTypeName | str | dict[str, Any]
+"""A data type accepted anywhere a `DataType` is required.
+
+Coerced into a `DataType` at the function boundary:
+
+- a `DataType` instance (used as-is),
+- a name string such as `"float32"` (see `DataTypeName`),
+- a Zarr v3 metadata `dict` such as `{"name": "float32"}`.
+"""
+
 
 __all__ = [
     "Array",
@@ -37,6 +72,8 @@ __all__ = [
     "AsyncGroup",
     "ChunkGrid",
     "DataType",
+    "DataTypeInput",
+    "DataTypeName",
     "DecodedArray",
     "FilesystemStore",
     "FillValue",

--- a/python/zarrista/__init__.py
+++ b/python/zarrista/__init__.py
@@ -1,6 +1,6 @@
 """A low-level Zarr API for Python, binding to Rust's Zarrs."""
 
-from typing import Any, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from . import codec, exceptions
 from ._zarrista import (
@@ -50,18 +50,8 @@ DataTypeName: TypeAlias = Literal[
 """The Zarr v3 names of the built-in fixed data types.
 
 Documents the common names for editor autocompletion; arbitrary strings (e.g.
-raw `"r*"` types or extension data types) are still accepted via `str` in
-`DataTypeInput`.
-"""
-
-DataTypeInput: TypeAlias = DataType | DataTypeName | str | dict[str, Any]
-"""A data type accepted anywhere a `DataType` is required.
-
-Coerced into a `DataType` at the function boundary:
-
-- a `DataType` instance (used as-is),
-- a name string such as `"float32"` (see `DataTypeName`),
-- a Zarr v3 metadata `dict` such as `{"name": "float32"}`.
+raw `"r*"` types or extension data types) are still accepted by
+`DataType.from_string`.
 """
 
 
@@ -72,7 +62,6 @@ __all__ = [
     "AsyncGroup",
     "ChunkGrid",
     "DataType",
-    "DataTypeInput",
     "DataTypeName",
     "DecodedArray",
     "FilesystemStore",

--- a/python/zarrista/_dtype.pyi
+++ b/python/zarrista/_dtype.pyi
@@ -19,10 +19,6 @@ DataTypeName: TypeAlias = Literal[
     "bytes",
 ]
 """The Zarr v3 names of the built-in fixed data types.
-
-Documents the common names for editor autocompletion; arbitrary strings (e.g.
-raw `"r*"` types or extension data types) are still accepted by
-[`DataType.from_string`][zarrista.DataType.from_string].
 """
 
 class DataType:

--- a/python/zarrista/_dtype.pyi
+++ b/python/zarrista/_dtype.pyi
@@ -28,7 +28,8 @@ raw `"r*"` types or extension data types) are still accepted by
 class DataType:
     """A Zarr v3 data type."""
 
-    def __init__(self, metadata: dict[str, Any]) -> None:
+    @staticmethod
+    def from_metadata(metadata: dict[str, Any]) -> DataType:
         """Construct a data type from its Zarr v3 metadata."""
     @staticmethod
     def from_string(name: DataTypeName | str) -> DataType:

--- a/python/zarrista/_dtype.pyi
+++ b/python/zarrista/_dtype.pyi
@@ -1,18 +1,5 @@
 from typing import Any, Literal, TypeAlias
 
-class DataType:
-    """A Zarr v3 data type."""
-
-    def __init__(self, metadata: dict[str, Any]) -> None:
-        """Construct a data type from its Zarr v3 metadata."""
-    @property
-    def name(self) -> str | None:
-        """The Zarr v3 data-type name (e.g. `"float64"`)."""
-    @property
-    def size(self) -> int | None:
-        """The fixed size in bytes, or `None` for variable-length data types."""
-    def __eq__(self, other: object) -> bool: ...
-
 DataTypeName: TypeAlias = Literal[
     "bool",
     "int8",
@@ -34,17 +21,22 @@ DataTypeName: TypeAlias = Literal[
 """The Zarr v3 names of the built-in fixed data types.
 
 Documents the common names for editor autocompletion; arbitrary strings (e.g.
-raw `"r*"` types or extension data types) are still accepted via `str` in
-[`DataTypeInput`][zarrista.DataTypeInput].
+raw `"r*"` types or extension data types) are still accepted by
+[`DataType.from_string`][zarrista.DataType.from_string].
 """
 
-DataTypeInput: TypeAlias = DataType | DataTypeName | str | dict[str, Any]
-"""A data type accepted anywhere a `DataType` is required.
+class DataType:
+    """A Zarr v3 data type."""
 
-Coerced into a [`DataType`][zarrista.DataType] at the function boundary:
-
-- a `DataType` instance (used as-is),
-- a name string such as `"float32"` (see
-  [`DataTypeName`][zarrista.DataTypeName]),
-- a Zarr v3 metadata `dict` such as `{"name": "float32"}`.
-"""
+    def __init__(self, metadata: dict[str, Any]) -> None:
+        """Construct a data type from its Zarr v3 metadata."""
+    @staticmethod
+    def from_string(name: DataTypeName | str) -> DataType:
+        """Construct a data type from its Zarr v3 name (e.g. `"float32"`)."""
+    @property
+    def name(self) -> str | None:
+        """The Zarr v3 data-type name (e.g. `"float64"`)."""
+    @property
+    def size(self) -> int | None:
+        """The fixed size in bytes, or `None` for variable-length data types."""
+    def __eq__(self, other: object) -> bool: ...

--- a/python/zarrista/_dtype.pyi
+++ b/python/zarrista/_dtype.pyi
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal, TypeAlias
 
 class DataType:
     """A Zarr v3 data type."""
@@ -12,3 +12,39 @@ class DataType:
     def size(self) -> int | None:
         """The fixed size in bytes, or `None` for variable-length data types."""
     def __eq__(self, other: object) -> bool: ...
+
+DataTypeName: TypeAlias = Literal[
+    "bool",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "float16",
+    "float32",
+    "float64",
+    "complex64",
+    "complex128",
+    "string",
+    "bytes",
+]
+"""The Zarr v3 names of the built-in fixed data types.
+
+Documents the common names for editor autocompletion; arbitrary strings (e.g.
+raw `"r*"` types or extension data types) are still accepted via `str` in
+[`DataTypeInput`][zarrista.DataTypeInput].
+"""
+
+DataTypeInput: TypeAlias = DataType | DataTypeName | str | dict[str, Any]
+"""A data type accepted anywhere a `DataType` is required.
+
+Coerced into a [`DataType`][zarrista.DataType] at the function boundary:
+
+- a `DataType` instance (used as-is),
+- a name string such as `"float32"` (see
+  [`DataTypeName`][zarrista.DataTypeName]),
+- a Zarr v3 metadata `dict` such as `{"name": "float32"}`.
+"""

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -83,7 +83,7 @@ impl FromPyObject<'_, '_> for PyDataType {
             // assume the metadata corresponds to a "name" if it cannot be parsed as MetadataV3
             // this makes "float32" work for example, where normally r#""float32""# would be required
             MetadataV3::try_from(string_type.as_str())
-                .unwrap_or(MetadataV3::new(string_type.as_str()))
+                .unwrap_or_else(|_| MetadataV3::new(string_type.as_str()))
         } else {
             obj.extract::<PyMetadataV3>()?.into_inner()
         };

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -3,12 +3,10 @@
 
 use std::borrow::Cow;
 
-use crate::error::ZarristaError;
+use crate::error::ZarristaResult;
 use crate::metadata::PyMetadataV3;
 use pyo3::prelude::*;
-use pyo3::pybacked::PyBackedStr;
-use pyo3::types::PyString;
-use zarrs::array::{ArrayCreateError, DataType, DataTypeSize};
+use zarrs::array::{DataType, DataTypeSize};
 use zarrs::metadata::v3::MetadataV3;
 
 #[derive(Debug, Clone)]
@@ -29,6 +27,14 @@ impl PyDataType {
     fn py_new(metadata: PyMetadataV3) -> Self {
         let data_type = DataType::from_metadata(&metadata.into_inner()).unwrap();
         PyDataType { inner: data_type }
+    }
+
+    /// Construct a data type from its Zarr v3 name (e.g. `"float32"`).
+    #[staticmethod]
+    fn from_string(name: &str) -> ZarristaResult<Self> {
+        let metadata = MetadataV3::new(name);
+        let data_type = DataType::from_metadata(&metadata)?;
+        Ok(Self { inner: data_type })
     }
 
     #[getter]
@@ -66,30 +72,5 @@ impl From<DataType> for PyDataType {
 impl From<PyDataType> for DataType {
     fn from(py_data_type: PyDataType) -> Self {
         py_data_type.inner
-    }
-}
-
-impl FromPyObject<'_, '_> for PyDataType {
-    type Error = ZarristaError;
-
-    // Taken from https://github.com/zarrs/zarrs/blob/38a7be3e51c0b7f2f6a88ba0859714ab07878cb4/zarrs/src/array/builder/array_builder_data_type.rs#L36-L52
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
-        if let Ok(slf) = obj.cast::<Self>() {
-            return Ok(slf.get().clone());
-        }
-
-        let metadata = if obj.is_instance_of::<PyString>() {
-            let string_type = obj.extract::<PyBackedStr>()?;
-            // assume the metadata corresponds to a "name" if it cannot be parsed as MetadataV3
-            // this makes "float32" work for example, where normally r#""float32""# would be required
-            MetadataV3::try_from(string_type.as_str())
-                .unwrap_or_else(|_| MetadataV3::new(string_type.as_str()))
-        } else {
-            obj.extract::<PyMetadataV3>()?.into_inner()
-        };
-
-        Ok(DataType::from_metadata(&metadata)
-            .map_err(ArrayCreateError::DataTypeCreateError)?
-            .into())
     }
 }

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -5,17 +5,14 @@ use std::borrow::Cow;
 
 use crate::error::ZarristaError;
 use crate::metadata::PyMetadataV3;
-use numpy::prelude::*;
-use numpy::IntoPyArray;
-use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::*;
-use pyo3::IntoPyObjectExt;
-use zarrs::array::{Array, ArraySubset};
-use zarrs::array::{ArrayError, ElementOwned};
-use zarrs::array::{DataType, DataTypeSize};
-use zarrs::storage::ReadableListableStorageTraits;
+use pyo3::pybacked::PyBackedStr;
+use pyo3::types::PyString;
+use zarrs::array::{ArrayCreateError, DataType, DataTypeSize};
+use zarrs::metadata::v3::MetadataV3;
 
-#[pyclass(module = "zarrista", frozen, name = "DataType")]
+#[derive(Debug, Clone)]
+#[pyclass(module = "zarrista", frozen, name = "DataType", skip_from_py_object)]
 pub struct PyDataType {
     inner: DataType,
 }
@@ -72,121 +69,27 @@ impl From<PyDataType> for DataType {
     }
 }
 
-/// The store trait object backing every zarrista array/group.
-pub(crate) type DynStorage = dyn ReadableListableStorageTraits;
+impl FromPyObject<'_, '_> for PyDataType {
+    type Error = ZarristaError;
 
-// The following helpers back the array-read path (numpy region/chunk reads),
-// which is still commented out in `array/sync.rs`. Allow dead code until those
-// methods are enabled.
+    // Taken from https://github.com/zarrs/zarrs/blob/38a7be3e51c0b7f2f6a88ba0859714ab07878cb4/zarrs/src/array/builder/array_builder_data_type.rs#L36-L52
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(slf) = obj.cast::<Self>() {
+            return Ok(slf.get().clone());
+        }
 
-/// A region of an array to read: either an explicit subset or a whole chunk.
-#[allow(dead_code)]
-pub(crate) enum Region<'a> {
-    Subset(&'a ArraySubset),
-    Chunk(&'a [u64]),
-}
+        let metadata = if obj.is_instance_of::<PyString>() {
+            let string_type = obj.extract::<PyBackedStr>()?;
+            // assume the metadata corresponds to a "name" if it cannot be parsed as MetadataV3
+            // this makes "float32" work for example, where normally r#""float32""# would be required
+            MetadataV3::try_from(string_type.as_str())
+                .unwrap_or(MetadataV3::new(string_type.as_str()))
+        } else {
+            obj.extract::<PyMetadataV3>()?.into_inner()
+        };
 
-#[allow(dead_code)]
-fn retrieve_vec<T: ElementOwned>(
-    array: &Array<DynStorage>,
-    region: &Region<'_>,
-) -> Result<Vec<T>, ArrayError> {
-    match region {
-        Region::Subset(subset) => array.retrieve_array_subset(*subset),
-        Region::Chunk(indices) => array.retrieve_chunk(indices),
+        Ok(DataType::from_metadata(&metadata)
+            .map_err(ArrayCreateError::DataTypeCreateError)?
+            .into())
     }
-}
-
-#[allow(dead_code)]
-fn vec_to_numpy<T: numpy::Element>(
-    py: Python<'_>,
-    data: Vec<T>,
-    shape: &[usize],
-) -> PyResult<Py<PyAny>> {
-    let array = data.into_pyarray(py);
-    let reshaped = array.reshape(shape.to_vec())?;
-    Ok(reshaped.into_any().unbind())
-}
-
-/// Read a region of `array` into a C-order numpy array of the given output
-/// shape. Only fixed-length numeric and boolean dtypes are supported so far.
-#[allow(dead_code)]
-pub(crate) fn read_region(
-    py: Python<'_>,
-    array: &Array<DynStorage>,
-    region: &Region<'_>,
-    out_shape: &[usize],
-) -> PyResult<Py<PyAny>> {
-    let name = array.data_type().name_v3();
-
-    macro_rules! arm {
-        ($t:ty) => {{
-            let data: Vec<$t> = retrieve_vec(array, region).map_err(ZarristaError::from)?;
-            vec_to_numpy(py, data, out_shape)
-        }};
-    }
-
-    match name.as_deref() {
-        Some("bool") => arm!(bool),
-        Some("int8") => arm!(i8),
-        Some("int16") => arm!(i16),
-        Some("int32") => arm!(i32),
-        Some("int64") => arm!(i64),
-        Some("uint8") => arm!(u8),
-        Some("uint16") => arm!(u16),
-        Some("uint32") => arm!(u32),
-        Some("uint64") => arm!(u64),
-        Some("float16") => arm!(half::f16),
-        Some("float32") => arm!(f32),
-        Some("float64") => arm!(f64),
-        other => Err(PyNotImplementedError::new_err(format!(
-            "reading dtype {:?} is not supported yet",
-            other.unwrap_or("<unknown>")
-        ))),
-    }
-}
-
-/// Convert a fill value (native-endian bytes) into a Python scalar, returning
-/// `None` for dtypes we do not yet interpret.
-#[allow(dead_code)]
-pub(crate) fn fill_value_to_py(
-    py: Python<'_>,
-    data_type: &DataType,
-    bytes: &[u8],
-) -> PyResult<Py<PyAny>> {
-    macro_rules! scalar {
-        ($t:ty) => {{
-            const N: usize = std::mem::size_of::<$t>();
-            match <[u8; N]>::try_from(bytes) {
-                Ok(arr) => <$t>::from_ne_bytes(arr).into_bound_py_any(py)?.unbind(),
-                Err(_) => py.None(),
-            }
-        }};
-    }
-
-    let dtype_name = data_type.name_v3();
-    let value = match dtype_name.as_deref() {
-        Some("bool") => (!bytes.is_empty() && bytes[0] != 0)
-            .into_bound_py_any(py)?
-            .unbind(),
-        Some("int8") => scalar!(i8),
-        Some("int16") => scalar!(i16),
-        Some("int32") => scalar!(i32),
-        Some("int64") => scalar!(i64),
-        Some("uint8") => scalar!(u8),
-        Some("uint16") => scalar!(u16),
-        Some("uint32") => scalar!(u32),
-        Some("uint64") => scalar!(u64),
-        Some("float16") => match <[u8; 2]>::try_from(bytes) {
-            Ok(arr) => half::f16::from_ne_bytes(arr)
-                .to_f32()
-                .into_bound_py_any(py)?
-                .unbind(),
-            Err(_) => py.None(),
-        },
-        Some("float32") => scalar!(f32),
-        Some("float64") => scalar!(f64),
-        _ => py.None(),
-    };
-    Ok(value)
 }

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -23,10 +23,11 @@ impl PyDataType {
 
 #[pymethods]
 impl PyDataType {
-    #[new]
-    fn py_new(metadata: PyMetadataV3) -> Self {
-        let data_type = DataType::from_metadata(&metadata.into_inner()).unwrap();
-        PyDataType { inner: data_type }
+    /// Construct a data type from its Zarr v3 metadata.
+    #[staticmethod]
+    fn from_metadata(metadata: PyMetadataV3) -> ZarristaResult<Self> {
+        let data_type = DataType::from_metadata(&metadata.into_inner())?;
+        Ok(Self { inner: data_type })
     }
 
     /// Construct a data type from its Zarr v3 name (e.g. `"float32"`).

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -25,7 +25,7 @@ def test_from_string_variable_length_has_no_size():
 
 
 def test_from_string_rejects_unknown_name():
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa: B017, PT011
         DataType.from_string("not_a_real_dtype")
 
 

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -2,8 +2,8 @@ import pytest
 from zarrista import DataType
 
 
-def test_construct_from_metadata():
-    dtype = DataType({"name": "float32"})
+def test_from_metadata():
+    dtype = DataType.from_metadata({"name": "float32"})
     assert dtype.name == "float32"
     assert dtype.size == 4
 
@@ -15,7 +15,9 @@ def test_from_string():
 
 
 def test_from_string_matches_metadata_construction():
-    assert DataType.from_string("float32") == DataType({"name": "float32"})
+    from_string = DataType.from_string("float32")
+    from_metadata = DataType.from_metadata({"name": "float32"})
+    assert from_string == from_metadata
 
 
 def test_from_string_variable_length_has_no_size():

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -1,0 +1,53 @@
+import pytest
+
+from zarrista import DataType
+
+
+def test_construct_from_metadata():
+    dtype = DataType({"name": "float32"})
+    assert dtype.name == "float32"
+    assert dtype.size == 4
+
+
+def test_variable_length_has_no_size():
+    dtype = DataType({"name": "string"})
+    assert dtype.size is None
+
+
+def test_eq_same_dtype():
+    assert DataType({"name": "float32"}) == DataType({"name": "float32"})
+
+
+def test_eq_different_dtype():
+    assert DataType({"name": "float32"}) != DataType({"name": "int8"})
+
+
+def test_eq_non_dtype_is_false():
+    # __eq__ is strict: a string is *not* equal to a DataType, even though a
+    # string can be *coerced* into one at function boundaries (see below).
+    assert DataType({"name": "float32"}) != "float32"
+
+
+def test_repr():
+    assert repr(DataType({"name": "float32"})) == "DataType(float32 / <f4)"
+
+
+# The `FromPyObject` coercion (str / dict / DataType -> DataType) is currently
+# only reachable through the scratch `extract_dtype` helper. Repoint these at a
+# real consumer (e.g. an array-creation API) once one exists, and delete the
+# scratch function.
+extract_dtype = pytest.importorskip("zarrista._zarrista").extract_dtype
+
+
+def test_coerce_from_string():
+    assert extract_dtype("float32") == DataType({"name": "float32"})
+
+
+def test_coerce_from_dtype_is_identity():
+    dtype = DataType({"name": "float32"})
+    assert extract_dtype(dtype) == dtype
+
+
+def test_coerce_rejects_unknown_name():
+    with pytest.raises(Exception):
+        extract_dtype("not_a_real_dtype")

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -1,5 +1,4 @@
 import pytest
-
 from zarrista import DataType
 
 
@@ -9,45 +8,38 @@ def test_construct_from_metadata():
     assert dtype.size == 4
 
 
-def test_variable_length_has_no_size():
-    dtype = DataType({"name": "string"})
-    assert dtype.size is None
+def test_from_string():
+    dtype = DataType.from_string("float32")
+    assert dtype.name == "float32"
+    assert dtype.size == 4
+
+
+def test_from_string_matches_metadata_construction():
+    assert DataType.from_string("float32") == DataType({"name": "float32"})
+
+
+def test_from_string_variable_length_has_no_size():
+    assert DataType.from_string("string").size is None
+
+
+def test_from_string_rejects_unknown_name():
+    with pytest.raises(Exception):
+        DataType.from_string("not_a_real_dtype")
 
 
 def test_eq_same_dtype():
-    assert DataType({"name": "float32"}) == DataType({"name": "float32"})
+    assert DataType.from_string("float32") == DataType.from_string("float32")
 
 
 def test_eq_different_dtype():
-    assert DataType({"name": "float32"}) != DataType({"name": "int8"})
+    assert DataType.from_string("float32") != DataType.from_string("int8")
 
 
 def test_eq_non_dtype_is_false():
-    # __eq__ is strict: a string is *not* equal to a DataType, even though a
-    # string can be *coerced* into one at function boundaries (see below).
-    assert DataType({"name": "float32"}) != "float32"
+    # __eq__ is strict: a string is not equal to a DataType. Conversion is
+    # explicit via `from_string`, never implicit.
+    assert DataType.from_string("float32") != "float32"
 
 
 def test_repr():
-    assert repr(DataType({"name": "float32"})) == "DataType(float32 / <f4)"
-
-
-# The `FromPyObject` coercion (str / dict / DataType -> DataType) is currently
-# only reachable through the scratch `extract_dtype` helper. Repoint these at a
-# real consumer (e.g. an array-creation API) once one exists, and delete the
-# scratch function.
-extract_dtype = pytest.importorskip("zarrista._zarrista").extract_dtype
-
-
-def test_coerce_from_string():
-    assert extract_dtype("float32") == DataType({"name": "float32"})
-
-
-def test_coerce_from_dtype_is_identity():
-    dtype = DataType({"name": "float32"})
-    assert extract_dtype(dtype) == dtype
-
-
-def test_coerce_rejects_unknown_name():
-    with pytest.raises(Exception):
-        extract_dtype("not_a_real_dtype")
+    assert repr(DataType.from_string("float32")) == "DataType(float32 / <f4)"


### PR DESCRIPTION
At first this PR was planned to be
```
Support string input wherever `DataType` is expected
```
which would have supported
```py
example_function(dtype: string | dict | DataType)
```
but that's kinda messy. Perhaps that's a good API for a higher level Zarr-Python API, but I think at the Zarrista level we should always aim to be _explicit_.

Instead, this PR just adds `DataType.from_name` and changes the existing constructor to `DataType.from_metadata`