### PR TITLE
docs: Add missing classes to Python API docs

### DIFF
--- a/docs/api/builder.md
+++ b/docs/api/builder.md
@@ -1,9 +1,9 @@
-# DataType
+# Array creation
 
-::: zarrista.DataType
+::: zarrista.ArrayBuilder
     options:
       show_bases: false
 
-::: zarrista.FillValue
+::: zarrista.ArrayBytes
     options:
       show_bases: false

--- a/docs/api/chunk-grid.md
+++ b/docs/api/chunk-grid.md
@@ -3,3 +3,7 @@
 ::: zarrista.ChunkGrid
     options:
       show_bases: false
+
+::: zarrista.ChunkKeyEncoding
+    options:
+      show_bases: false

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -1,0 +1,3 @@
+# Exceptions
+
+::: zarrista.exceptions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,12 +22,14 @@ nav:
   - "index.md"
   - API Reference:
       - api/array.md
+      - api/builder.md
       - api/group.md
       - api/store.md
       - api/chunk-grid.md
       - api/codec.md
       - api/decoded_array.md
       - api/dtype.md
+      - api/exceptions.md
   - Blog:
       - blog/index.md
 


### PR DESCRIPTION
Small PR to add missing API pages to the docs