### PR TITLE
chore: Bump to 0.1.0-beta.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "zarrista"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrista"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 authors = ["Kyle Barron <kyle@developmentseed.org>"]
 edition = "2021"
 description = "A small, prototypical zarrita-like Python Zarr implementation on top of zarrs."


### PR DESCRIPTION
Lets us publish free-threaded wheels for 3.14 (#69 )