### PR TITLE
fix: Patch upstream monostate-serde bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,8 +2663,7 @@ dependencies = [
 [[package]]
 name = "monostate"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4cc965c89dd0615a9e822ff8002f7633d2466143d51bd58693e4b2c75aabad"
+source = "git+https://github.com/kylebarron/monostate?rev=b62913f1076318b1bced0f199cd4de036dc61e46#b62913f1076318b1bced0f199cd4de036dc61e46"
 dependencies = [
  "monostate-impl",
  "serde",
@@ -2674,8 +2673,7 @@ dependencies = [
 [[package]]
 name = "monostate-impl"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f5b99488110875b5904839d396c2cdfaf241ff6622638acb879cc7effad5de"
+source = "git+https://github.com/kylebarron/monostate?rev=b62913f1076318b1bced0f199cd4de036dc61e46#b62913f1076318b1bced0f199cd4de036dc61e46"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,4 @@ codegen-units = 1
 # Branch kyle/v0.23-derive-clone
 zarrs = { git = "https://github.com/kylebarron/zarrs", rev = "e68838becd223ddb7f522b265c1b65b90fe577b1" }
 zarrs_storage = { git = "https://github.com/kylebarron/zarrs", rev = "e68838becd223ddb7f522b265c1b65b90fe577b1" }
+monostate = { git = "https://github.com/kylebarron/monostate", rev = "b62913f1076318b1bced0f199cd4de036dc61e46" }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,4 +1,5 @@
 use pyo3::prelude::*;
+use pyo3::exceptions::PyValueError;
 use pythonize::{depythonize, pythonize, PythonizeError};
 use serde_json::{Map, Value};
 use zarrs::metadata::v2::{ArrayMetadataV2, GroupMetadataV2, MetadataV2};
@@ -20,10 +21,14 @@ macro_rules! pythonized_metadata {
         }
 
         impl<'a, 'py> FromPyObject<'a, 'py> for $name {
-            type Error = PythonizeError;
+            type Error = PyErr;
 
             fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
-                Ok($name(depythonize(&obj)?))
+                // depythonize into a serde `Value`` to ensure that whole numbers are 
+                // stored with u64, which zarrs_metadata expects for e.g. the zarr_format
+                // field
+                let val: Value = depythonize(&obj)?;
+                Ok($name(serde_json::from_value(val).map_err(|e| PyValueError::new_err(e.to_string()))?))
             }
         }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,4 +1,3 @@
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pythonize::{depythonize, pythonize, PythonizeError};
 use serde_json::{Map, Value};
@@ -21,17 +20,10 @@ macro_rules! pythonized_metadata {
         }
 
         impl<'a, 'py> FromPyObject<'a, 'py> for $name {
-            type Error = PyErr;
+            type Error = PythonizeError;
 
             fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
-                // depythonize into a serde `Value`` to ensure that whole numbers are
-                // stored with u64, which zarrs_metadata expects for e.g. the zarr_format
-                // field
-                let val: Value = depythonize(&obj)?;
-                Ok($name(
-                    serde_json::from_value(val)
-                        .map_err(|e| PyValueError::new_err(e.to_string()))?,
-                ))
+                Ok($name(depythonize(&obj)?))
             }
         }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,5 +1,5 @@
-use pyo3::prelude::*;
 use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 use pythonize::{depythonize, pythonize, PythonizeError};
 use serde_json::{Map, Value};
 use zarrs::metadata::v2::{ArrayMetadataV2, GroupMetadataV2, MetadataV2};
@@ -24,11 +24,14 @@ macro_rules! pythonized_metadata {
             type Error = PyErr;
 
             fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
-                // depythonize into a serde `Value`` to ensure that whole numbers are 
+                // depythonize into a serde `Value`` to ensure that whole numbers are
                 // stored with u64, which zarrs_metadata expects for e.g. the zarr_format
                 // field
                 let val: Value = depythonize(&obj)?;
-                Ok($name(serde_json::from_value(val).map_err(|e| PyValueError::new_err(e.to_string()))?))
+                Ok($name(
+                    serde_json::from_value(val)
+                        .map_err(|e| PyValueError::new_err(e.to_string()))?,
+                ))
             }
         }
 

--- a/tests/array/test_array.py
+++ b/tests/array/test_array.py
@@ -1,6 +1,7 @@
 from zarr_metadata import ArrayMetadataV3
 import zarrista
 
+
 def test_array_from_metadata():
     """
     Test that Array.from_metadata works
@@ -12,7 +13,7 @@ def test_array_from_metadata():
         "attributes": {},
         "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": (2, 2)}},
         "data_type": "int16",
-        "chunk_key_encoding": {"name": "default", "configuration": {"separator": "/" }},
+        "chunk_key_encoding": {"name": "default", "configuration": {"separator": "/"}},
         "fill_value": 0,
         "node_type": "array",
         "shape": (4, 4),

--- a/tests/array/test_array.py
+++ b/tests/array/test_array.py
@@ -1,4 +1,3 @@
-
 from typing import TYPE_CHECKING
 
 import zarrista

--- a/tests/array/test_array.py
+++ b/tests/array/test_array.py
@@ -1,0 +1,22 @@
+from zarr_metadata import ArrayMetadataV3
+import zarrista
+
+def test_array_from_metadata():
+    """
+    Test that Array.from_metadata works
+    """
+    store = zarrista.MemoryStore()
+
+    meta: ArrayMetadataV3 = {
+        "zarr_format": 3,
+        "attributes": {},
+        "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": (2, 2)}},
+        "data_type": "int16",
+        "chunk_key_encoding": {"name": "default", "configuration": {"separator": "/" }},
+        "fill_value": 0,
+        "node_type": "array",
+        "shape": (4, 4),
+        "codecs": ({"name": "bytes"},),
+    }
+
+    a = zarrista.Array.from_metadata(meta, store)

--- a/tests/array/test_array.py
+++ b/tests/array/test_array.py
@@ -1,5 +1,10 @@
-from zarr_metadata import ArrayMetadataV3
+
+from typing import TYPE_CHECKING
+
 import zarrista
+
+if TYPE_CHECKING:
+    from zarr_metadata import ArrayMetadataV3
 
 
 def test_array_from_metadata():
@@ -20,4 +25,4 @@ def test_array_from_metadata():
         "codecs": ({"name": "bytes"},),
     }
 
-    a = zarrista.Array.from_metadata(meta, store)
+    zarrista.Array.from_metadata(meta, store)


### PR DESCRIPTION
the added test case fails on main with an obscure error:

```python
def test_array_from_metadata():
    """
    Test that Array.from_metadata works
    """
    store = zarrista.MemoryStore()

    meta: ArrayMetadataV3 = {
        "zarr_format": 3,
        "attributes": {},
        "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": (2, 2)}},
        "data_type": "int16",
        "chunk_key_encoding": {"name": "default", "configuration": {"separator": "/" }},
        "fill_value": 0,
        "node_type": "array",
        "shape": (4, 4),
        "codecs": ({"name": "bytes"},),
    }

    a = zarrista.Array.from_metadata(meta, store)
```
```
>       a = zarrista.Array.from_metadata(meta, store)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Exception: data did not match any variant of untagged enum ArrayMetadata
E       while processing 'metadata'
```

The underlying issue (discovered by claude) is that `zarr_format` is annotated as [`monostate:MustBe!(u64)`](https://github.com/zarrs/zarrs/blob/f9f2452441b8e753949da540727d5ec5a19030b9/zarrs_metadata/src/v3/array.rs#L57), but depythonize with a python int for `zarr_format` gives us `u8`, which obviously isn't `u64`. So this PR depythonizes into a serde `Value` first, which (im told) consistently uses `u64` for natural numbers like `3`. That makes the test pass.

### Change list

- We fix this by patching to use https://github.com/dtolnay/monostate/pull/32.
- Added test
