### PR TITLE
refactor: Move stores into `store` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ This project is for **evaluation**, to consider whether natively binding to [Zar
 Open a store, then open an `Array` from it:
 
 ```py
-from zarrista import Array, FilesystemStore
+from zarrista import Array
+from zarrista.store import FilesystemStore
 
 store = FilesystemStore("data/example.zarr")
 array = Array.open(store, path="/temperature")

--- a/docs/api/store.md
+++ b/docs/api/store.md
@@ -1,9 +1,13 @@
 # Stores
 
-::: zarrista.FilesystemStore
+::: zarrista.store.FilesystemStore
     options:
       show_bases: false
 
-::: zarrista.MemoryStore
+::: zarrista.store.MemoryStore
+    options:
+      show_bases: false
+
+::: zarrista.store.AsyncStore
     options:
       show_bases: false

--- a/python/zarrista/__init__.py
+++ b/python/zarrista/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TypeAlias
 
-from . import codec, exceptions
+from . import codec, exceptions, store
 from ._zarrista import (
     Array,
     ArrayBuilder,
@@ -12,12 +12,10 @@ from ._zarrista import (
     ChunkGrid,
     ChunkKeyEncoding,
     DataType,
-    FilesystemStore,
     FillValue,
     Group,
     MaskedTensor,
     MaskedVariableArray,
-    MemoryStore,
     Tensor,
     VariableArray,
     __version__,
@@ -42,15 +40,14 @@ __all__ = [
     "ChunkKeyEncoding",
     "DataType",
     "DecodedArray",
-    "FilesystemStore",
     "FillValue",
     "Group",
     "MaskedTensor",
     "MaskedVariableArray",
-    "MemoryStore",
     "Tensor",
     "VariableArray",
     "__version__",
     "codec",
     "exceptions",
+    "store",
 ]

--- a/python/zarrista/store.py
+++ b/python/zarrista/store.py
@@ -1,0 +1,28 @@
+"""Available stores."""
+
+from typing import TypeAlias
+
+from icechunk import Session
+from obstore.store import ObjectStore
+
+from ._zarrista import FilesystemStore, MemoryStore
+
+AsyncStore: TypeAlias = ObjectStore | Session
+"""A store accepted by the async API.
+
+Either an obstore [`ObjectStore`][obstore.store.ObjectStore] (any object-store
+backend, e.g. S3, GCS, local) or an icechunk [`Session`][icechunk.Session]
+(a transactional, versioned store).
+
+Note: an icechunk `Session` is serialized and reconstructed inside the Rust
+extension, which runs as a separate icechunk instance. The session's data must
+therefore live in storage that instance can also read (local filesystem, S3,
+etc.). Sessions backed by `icechunk.in_memory_storage()` will not work, since
+that data only exists in the Python process and reads will fail to find it.
+"""
+
+
+__all__ = [
+    "FilesystemStore",
+    "MemoryStore",
+]

--- a/tests/array/test_array.py
+++ b/tests/array/test_array.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
-import zarrista
+from zarrista import Array
+from zarrista.store import MemoryStore
 
 if TYPE_CHECKING:
     from zarr_metadata import ArrayMetadataV3
@@ -10,7 +11,7 @@ def test_array_from_metadata():
     """
     Test that Array.from_metadata works
     """
-    store = zarrista.MemoryStore()
+    store = MemoryStore()
 
     meta: ArrayMetadataV3 = {
         "zarr_format": 3,
@@ -24,4 +25,4 @@ def test_array_from_metadata():
         "codecs": ({"name": "bytes"},),
     }
 
-    zarrista.Array.from_metadata(meta, store)
+    Array.from_metadata(meta, store)

--- a/tests/array/test_array.py
+++ b/tests/array/test_array.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from zarr_metadata import ArrayMetadataV3
 
 
-def test_array_from_metadata():
+def test_array_from_metadata() -> None:
     """
     Test that Array.from_metadata works
     """

--- a/tests/array/test_read_only.py
+++ b/tests/array/test_read_only.py
@@ -3,16 +3,9 @@
 import numpy as np
 import pytest
 
-from zarrista import (
-    Array,
-    ArrayBuilder,
-    ArrayBytes,
-    ChunkGrid,
-    DataType,
-    FillValue,
-    MemoryStore,
-)
+from zarrista import Array, ArrayBuilder, ArrayBytes, ChunkGrid, DataType, FillValue
 from zarrista.exceptions import ZarristaError
+from zarrista.store import MemoryStore
 
 
 def _writable_array() -> Array:

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -12,7 +12,8 @@ import zarr
 from arro3.core import Array as Arro3Array
 from arro3.core import DataType
 
-from zarrista import Array, FilesystemStore, VariableArray
+from zarrista import Array, VariableArray
+from zarrista.store import FilesystemStore
 
 
 def test_variable_length_string_to_arrow(tmp_path: Path):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -8,11 +8,11 @@ from zarrista import (
     ChunkKeyEncoding,
     DataType,
     FillValue,
-    MemoryStore,
     codec,
 )
 from zarrista.codec import ArrayToBytesCodec
 from zarrista.exceptions import ChunkGridCreateError, ZarristaError
+from zarrista.store import MemoryStore
 
 
 def _builder() -> ArrayBuilder:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -6,8 +6,9 @@ from pathlib import Path
 import pytest
 import zarr
 
-from zarrista import FilesystemStore, Group
+from zarrista import Group
 from zarrista import exceptions as exc
+from zarrista.store import FilesystemStore
 
 LEAF_EXCEPTIONS = [
     "ArrayCreateError",

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -14,14 +14,9 @@ import pytest
 import zarr
 from obstore.store import LocalStore
 
-from zarrista import (
-    Array,
-    AsyncArray,
-    AsyncGroup,
-    FilesystemStore,
-    Group,
-)
+from zarrista import Array, AsyncArray, AsyncGroup, Group
 from zarrista.exceptions import ZarristaError
+from zarrista.store import FilesystemStore
 
 
 @pytest.fixture

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -13,7 +13,8 @@ import zarr
 from numpy.typing import NDArray
 from obstore.store import LocalStore
 
-from zarrista import Array, AsyncArray, FilesystemStore, Tensor
+from zarrista import Array, AsyncArray, Tensor
+from zarrista.store import FilesystemStore
 
 
 @pytest.fixture

--- a/tests/test_store_input.py
+++ b/tests/test_store_input.py
@@ -10,7 +10,8 @@ import numpy as np
 import pytest
 import zarr
 
-from zarrista import Array, FilesystemStore, Group
+from zarrista import Array, Group
+from zarrista.store import FilesystemStore
 
 
 @pytest.fixture


### PR DESCRIPTION
Store imports now from `.store`

Closes #74 