### PR TITLE
feat: Add numpy export to MaskedTensor

### DIFF
--- a/python/zarrista/_decoded_array.pyi
+++ b/python/zarrista/_decoded_array.pyi
@@ -1,6 +1,7 @@
 import sys
 from typing import Any, TypeAlias
 
+import numpy as np
 from numpy.typing import DTypeLike, NDArray
 
 from ._dtype import DataType
@@ -88,7 +89,8 @@ class VariableArray:
 class MaskedTensor:
     """Fixed-width decoded data with a validity mask.
 
-    Not yet exposed to NumPy.
+    Use `to_numpy` (or `np.asarray`/`np.array`) to get a `numpy.ma.MaskedArray`
+    view over the underlying Rust memory.
     """
 
     @property
@@ -97,6 +99,24 @@ class MaskedTensor:
     @property
     def dtype(self) -> DataType:
         """The Zarr data type."""
+    @property
+    def data(self) -> Tensor:
+        """The values, without the mask applied."""
+    @property
+    def mask(self) -> Tensor:
+        """The validity mask (`bool`, `True` = valid/present)."""
+    def to_numpy(self) -> np.ma.MaskedArray:
+        """Convert to a `numpy.ma.MaskedArray` view over Rust memory.
+
+        NumPy's masked-array convention is the inverse of ours: `True` marks
+        *masked* (missing) elements, so the validity mask is negated.
+        """
+    def __array__(
+        self,
+        dtype: DTypeLike | None = None,
+        copy: bool | None = None,
+    ) -> np.ma.MaskedArray:
+        """NumPy array-coercion protocol backing `np.asarray`/`np.array`."""
 
 class MaskedVariableArray:
     """Variable-length decoded data with a validity mask.

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -27,11 +27,12 @@ pub use tensor::{PyMaskedTensor, PyTensor};
 pub use variable::{PyMaskedVariableArray, PyVariableArray};
 
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
-use zarrs::array::{ArrayBytes, ArrayError, DataType, FromArrayBytes};
+use zarrs::array::{ArrayBytes, ArrayError, DataType, FromArrayBytes, data_type};
 
 /// Internal decoded result, produced by our [`FromArrayBytes`] impl. Carries the
 /// post-codec bytes (zero-copy), the data type, and the region shape (which
@@ -49,7 +50,7 @@ impl FromArrayBytes for DecodedArray {
         shape: &[u64],
         data_type: &DataType,
     ) -> Result<Self, ArrayError> {
-        let shape = shape.to_vec();
+        let shape = Arc::from(shape);
         let data_type = data_type.clone();
         Ok(match bytes {
             ArrayBytes::Fixed(bytes) => {
@@ -68,10 +69,8 @@ impl FromArrayBytes for DecodedArray {
                 let (data, mask) = optional.into_parts();
                 match *data {
                     ArrayBytes::Fixed(fixed) => DecodedArray::MaskedTensor(PyMaskedTensor::new(
-                        cow_to_bytes(fixed),
-                        cow_to_bytes(mask),
-                        data_type,
-                        shape,
+                        PyTensor::new(cow_to_bytes(fixed), data_type, shape.clone()),
+                        PyTensor::new(cow_to_bytes(mask), data_type::bool(), shape),
                     )),
                     ArrayBytes::Variable(variable) => {
                         let (buf, offsets) = variable.into_parts();

--- a/src/data/tensor.rs
+++ b/src/data/tensor.rs
@@ -1,4 +1,5 @@
 use std::ffi::{c_int, c_void};
+use std::sync::Arc;
 
 use bytes::Bytes;
 use dlpark::SafeManagedTensor;
@@ -24,12 +25,12 @@ use crate::error::{ZarristaError, ZarristaResult};
 pub struct PyTensor {
     bytes: Bytes,
     data_type: DataType,
-    shape: Vec<u64>,
+    shape: Arc<[u64]>,
 }
 
 impl PyTensor {
     /// Construct a new PyTensor from the given bytes, data type, and shape.
-    pub fn new(bytes: Bytes, data_type: DataType, shape: Vec<u64>) -> Self {
+    pub fn new(bytes: Bytes, data_type: DataType, shape: Arc<[u64]>) -> Self {
         Self {
             bytes,
             data_type,
@@ -37,7 +38,7 @@ impl PyTensor {
         }
     }
 
-    pub fn into_inner(self) -> (Bytes, DataType, Vec<u64>) {
+    pub fn into_inner(self) -> (Bytes, DataType, Arc<[u64]>) {
         (self.bytes, self.data_type, self.shape)
     }
 }
@@ -72,7 +73,7 @@ impl PyTensor {
         })?;
         let np = py.import("numpy")?;
         let flat = np.call_method1("frombuffer", (self.buffer(), name.into_owned()))?;
-        flat.call_method1("reshape", (&self.shape,))
+        flat.call_method1("reshape", (&*self.shape,))
     }
 
     /// NumPy array-coercion protocol backing `np.asarray(tensor)` /
@@ -208,24 +209,15 @@ impl TensorLike<RowMajorCompactLayout> for PyTensor {
 /// Fixed-width data with a validity mask. Skeleton.
 #[pyclass(module = "zarrista", frozen, name = "MaskedTensor")]
 pub struct PyMaskedTensor {
-    #[expect(dead_code)]
-    bytes: Bytes,
+    data: PyTensor,
     /// The mask is 1 byte per element where 0 = invalid/missing, non-zero = valid/present.
-    #[expect(dead_code)]
-    mask: Bytes,
-    data_type: DataType,
-    shape: Vec<u64>,
+    mask: PyTensor,
 }
 
 impl PyMaskedTensor {
     /// Construct a new PyMaskedTensor from the given bytes, mask, data type, and shape.
-    pub fn new(bytes: Bytes, mask: Bytes, data_type: DataType, shape: Vec<u64>) -> Self {
-        Self {
-            bytes,
-            mask,
-            data_type,
-            shape,
-        }
+    pub fn new(data: PyTensor, mask: PyTensor) -> Self {
+        Self { data, mask }
     }
 }
 
@@ -233,11 +225,21 @@ impl PyMaskedTensor {
 impl PyMaskedTensor {
     #[getter]
     fn shape(&self) -> &[u64] {
-        &self.shape
+        &self.data.shape
+    }
+
+    #[getter]
+    fn data(&self) -> PyTensor {
+        self.data.clone()
     }
 
     #[getter]
     fn dtype(&self) -> PyDataType {
-        self.data_type.clone().into()
+        self.data.data_type.clone().into()
+    }
+
+    #[getter]
+    fn mask(&self) -> PyTensor {
+        self.mask.clone()
     }
 }

--- a/src/data/tensor.rs
+++ b/src/data/tensor.rs
@@ -242,4 +242,51 @@ impl PyMaskedTensor {
     fn mask(&self) -> PyTensor {
         self.mask.clone()
     }
+
+    /// Convert to a NumPy masked array (`numpy.ma.MaskedArray`).
+    ///
+    /// The data and mask are NumPy views over the underlying Rust memory. NumPy's
+    /// masked-array convention is the inverse of ours — `True` marks *masked*
+    /// (missing) elements — so our validity mask (non-zero = valid) is negated.
+    fn to_numpy<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let data = self.data.to_numpy(py)?;
+        let valid = self.mask.to_numpy(py)?;
+        let np = py.import("numpy")?;
+        let masked = np.call_method1("logical_not", (valid,))?;
+        np.getattr("ma")?.call_method1("masked_array", (data, masked))
+    }
+
+    /// NumPy array-coercion protocol backing `np.asarray(tensor)` /
+    /// `np.array(tensor)`. Returns a `numpy.ma.MaskedArray`.
+    #[pyo3(signature = (dtype=None, copy=None))]
+    fn __array__<'py>(
+        &self,
+        py: Python<'py>,
+        dtype: Option<Bound<'py, PyAny>>,
+        copy: Option<bool>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let arr = self.to_numpy(py)?;
+
+        // copy=False demands zero-copy, so we can only hand back our own view.
+        if copy == Some(false) {
+            if let Some(dt) = &dtype {
+                let requested = py.import("numpy")?.call_method1("dtype", (dt,))?;
+                let current = arr.getattr("dtype")?;
+                if !requested.eq(&current)? {
+                    return Err(PyValueError::new_err(
+                        "cannot return a zero-copy array with a different dtype",
+                    ));
+                }
+            }
+            return Ok(arr);
+        }
+
+        if let Some(dt) = dtype {
+            arr.call_method1("astype", (dt,))
+        } else if copy == Some(true) {
+            arr.call_method0("copy")
+        } else {
+            Ok(arr)
+        }
+    }
 }

--- a/src/data/tensor.rs
+++ b/src/data/tensor.rs
@@ -253,7 +253,8 @@ impl PyMaskedTensor {
         let valid = self.mask.to_numpy(py)?;
         let np = py.import("numpy")?;
         let masked = np.call_method1("logical_not", (valid,))?;
-        np.getattr("ma")?.call_method1("masked_array", (data, masked))
+        np.getattr("ma")?
+            .call_method1("masked_array", (data, masked))
     }
 
     /// NumPy array-coercion protocol backing `np.asarray(tensor)` /

--- a/src/data/variable.rs
+++ b/src/data/variable.rs
@@ -19,11 +19,11 @@ pub struct PyVariableArray {
     bytes: Bytes,
     offsets: Vec<usize>,
     data_type: DataType,
-    shape: Vec<u64>,
+    shape: Arc<[u64]>,
 }
 
 impl PyVariableArray {
-    pub fn new(bytes: Bytes, offsets: Vec<usize>, data_type: DataType, shape: Vec<u64>) -> Self {
+    pub fn new(bytes: Bytes, offsets: Vec<usize>, data_type: DataType, shape: Arc<[u64]>) -> Self {
         Self {
             bytes,
             offsets,
@@ -123,7 +123,7 @@ pub struct PyMaskedVariableArray {
     #[expect(dead_code)]
     mask: Bytes,
     data_type: DataType,
-    shape: Vec<u64>,
+    shape: Arc<[u64]>,
 }
 
 impl PyMaskedVariableArray {
@@ -133,7 +133,7 @@ impl PyMaskedVariableArray {
         offsets: Vec<usize>,
         mask: Bytes,
         data_type: DataType,
-        shape: Vec<u64>,
+        shape: Arc<[u64]>,
     ) -> Self {
         Self {
             bytes,


### PR DESCRIPTION
A `MaskedTensor` is a normal Tensor with an associated element mask.

This supports exporting it as a numpy masked array