### PR TITLE
feat: Read shards/subchunks

### DIFF
--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -130,6 +130,25 @@ class Array:
         The bytes are returned verbatim, without running the codec pipeline.
         Returns `None` if the chunk is absent from the store.
         """
+    def retrieve_subchunk(
+        self,
+        subchunk_indices: list[int],
+        **codec_options: Unpack[CodecOptions],
+    ) -> DecodedArray:
+        """Read and decode a single subchunk (inner chunk) of a sharded array.
+
+        `subchunk_indices` index the subchunk grid (see `subchunk_grid_shape`). For
+        an unsharded array a subchunk is a whole chunk. Only the addressed inner
+        chunk is read from its shard rather than the entire shard.
+
+        Keyword arguments are passed as [`CodecOptions`][zarrista.codec.CodecOptions].
+        """
+    def retrieve_encoded_subchunk(self, subchunk_indices: list[int]) -> Buffer | None:
+        """Read the raw, still-encoded bytes of a subchunk of a sharded array.
+
+        The bytes are returned verbatim, without running the codec pipeline.
+        Returns `None` if the subchunk is absent from the store.
+        """
     def store_chunk(
         self,
         chunk_indices: list[int],
@@ -327,6 +346,28 @@ class AsyncArray:
 
         The bytes are returned verbatim, without running the codec pipeline.
         Returns `None` if the chunk is absent from the store.
+        """
+    async def retrieve_subchunk(
+        self,
+        subchunk_indices: list[int],
+        **codec_options: Unpack[CodecOptions],
+    ) -> DecodedArray:
+        """Read and decode a single subchunk (inner chunk) of a sharded array.
+
+        `subchunk_indices` index the subchunk grid (see `subchunk_grid_shape`). For
+        an unsharded array a subchunk is a whole chunk. Only the addressed inner
+        chunk is read from its shard rather than the entire shard.
+
+        Keyword arguments are passed as [`CodecOptions`][zarrista.codec.CodecOptions].
+        """
+    async def retrieve_encoded_subchunk(
+        self,
+        subchunk_indices: list[int],
+    ) -> Buffer | None:
+        """Read the raw, still-encoded bytes of a subchunk of a sharded array.
+
+        The bytes are returned verbatim, without running the codec pipeline.
+        Returns `None` if the subchunk is absent from the store.
         """
     async def store_chunk(
         self,

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -15,7 +15,7 @@ use crate::storage::{AsyncReadOnlyStorageAdapter, PyAsyncStorage};
 use pyo3::prelude::*;
 use pyo3_async_runtimes::tokio::future_into_py;
 use pyo3_bytes::PyBytes;
-use zarrs::array::Array;
+use zarrs::array::{Array, AsyncArrayShardedReadableExt, AsyncArrayShardedReadableExtCache};
 use zarrs::storage::AsyncReadableWritableListableStorageTraits;
 
 /// A Zarr array.
@@ -109,7 +109,7 @@ impl PyAsyncArray {
 
         future_into_py(py, async move {
             let result = inner
-                .async_compact_chunk(chunk_indices.as_ref(), &codec_options)
+                .async_compact_chunk(&chunk_indices, &codec_options)
                 .await
                 .map_err(ZarristaError::from)?;
             Ok(result)
@@ -124,7 +124,7 @@ impl PyAsyncArray {
         let inner = self.inner.clone();
         future_into_py(py, async move {
             inner
-                .async_erase_chunk(chunk_indices.as_ref())
+                .async_erase_chunk(&chunk_indices)
                 .await
                 .map_err(ZarristaError::from)?;
             Ok(())
@@ -181,7 +181,7 @@ impl PyAsyncArray {
 
         future_into_py(py, async move {
             let decoded = inner
-                .async_retrieve_chunk_opt::<DecodedArray>(chunk_indices.as_ref(), &codec_options)
+                .async_retrieve_chunk_opt::<DecodedArray>(&chunk_indices, &codec_options)
                 .await
                 .map_err(ZarristaError::from)?;
             Ok(decoded)
@@ -196,10 +196,56 @@ impl PyAsyncArray {
         let inner = self.inner.clone();
         future_into_py(py, async move {
             let encoded = inner
-                .async_retrieve_encoded_chunk(chunk_indices.as_ref())
+                .async_retrieve_encoded_chunk(&chunk_indices)
                 .await
                 .map_err(ZarristaError::from)?;
             Ok(encoded.map(PyBytes::new))
+        })
+    }
+
+    fn retrieve_encoded_subchunk<'py>(
+        &self,
+        py: Python<'py>,
+        subchunk_indices: PyChunkIndices,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        // TODO: allow user to manage shard cache
+        let subchunk_cache = AsyncArrayShardedReadableExtCache::new(&self.inner);
+
+        let inner = self.inner.clone();
+        future_into_py(py, async move {
+            let encoded = inner
+                .async_retrieve_encoded_subchunk(&subchunk_cache, &subchunk_indices)
+                .await
+                .map_err(ZarristaError::from)?;
+            Ok(encoded.map(|buf| PyBytes::new(buf.into())))
+        })
+    }
+
+    #[pyo3(signature = (subchunk_indices, **codec_options))]
+    fn retrieve_subchunk<'py>(
+        &self,
+        py: Python<'py>,
+        subchunk_indices: PyChunkIndices,
+        codec_options: Option<PyCodecOptions>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let codec_options = codec_options
+            .map(|opts| opts.into_inner())
+            .unwrap_or_default();
+
+        // TODO: allow user to manage shard cache
+        let subchunk_cache = AsyncArrayShardedReadableExtCache::new(&self.inner);
+
+        let inner = self.inner.clone();
+        future_into_py(py, async move {
+            let decoded = inner
+                .async_retrieve_subchunk_opt::<DecodedArray>(
+                    &subchunk_cache,
+                    &subchunk_indices,
+                    &codec_options,
+                )
+                .await
+                .map_err(ZarristaError::from)?;
+            Ok(decoded)
         })
     }
 
@@ -219,7 +265,7 @@ impl PyAsyncArray {
         future_into_py(py, async move {
             inner
                 .async_store_chunk_opt(
-                    chunk_indices.as_ref(),
+                    &chunk_indices,
                     decoded_chunk.as_array_bytes()?,
                     &codec_options,
                 )
@@ -241,7 +287,7 @@ impl PyAsyncArray {
             // The responsibility is on the caller to ensure the chunk is encoded correctly
             unsafe {
                 inner
-                    .async_store_encoded_chunk(chunk_indices.as_ref(), encoded_chunk.into_inner())
+                    .async_store_encoded_chunk(&chunk_indices, encoded_chunk.into_inner())
                     .await
                     .map_err(ZarristaError::from)?;
             }

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -14,7 +14,7 @@ use crate::node::PyNodePath;
 use crate::storage::{PySyncStorage, ReadOnlyStorageAdapter};
 use pyo3::prelude::*;
 use pyo3_bytes::PyBytes;
-use zarrs::array::Array;
+use zarrs::array::{Array, ArrayShardedReadableExt, ArrayShardedReadableExtCache};
 use zarrs::storage::ReadableWritableListableStorageTraits;
 
 /// A Zarr array.
@@ -89,13 +89,11 @@ impl PyArray {
         let codec_options = codec_options
             .map(|opts| opts.into_inner())
             .unwrap_or_default();
-        Ok(self
-            .inner
-            .compact_chunk(chunk_indices.as_ref(), &codec_options)?)
+        Ok(self.inner.compact_chunk(&chunk_indices, &codec_options)?)
     }
 
     fn erase_chunk(&self, chunk_indices: PyChunkIndices) -> ZarristaResult<()> {
-        self.inner.erase_chunk(chunk_indices.as_ref())?;
+        self.inner.erase_chunk(&chunk_indices)?;
         Ok(())
     }
 
@@ -130,15 +128,46 @@ impl PyArray {
             .unwrap_or_default();
         Ok(self
             .inner
-            .retrieve_chunk_opt(chunk_indices.as_ref(), &codec_options)?)
+            .retrieve_chunk_opt(&chunk_indices, &codec_options)?)
     }
 
     fn retrieve_encoded_chunk(
         &self,
         chunk_indices: PyChunkIndices,
     ) -> ZarristaResult<Option<PyBytes>> {
-        let encoded = self.inner.retrieve_encoded_chunk(chunk_indices.as_ref())?;
+        let encoded = self.inner.retrieve_encoded_chunk(&chunk_indices)?;
         Ok(encoded.map(|buf| PyBytes::new(buf.into())))
+    }
+
+    fn retrieve_encoded_subchunk(
+        &self,
+        subchunk_indices: PyChunkIndices,
+    ) -> ZarristaResult<Option<PyBytes>> {
+        // TODO: allow user to manage shard cache
+        let subchunk_cache = ArrayShardedReadableExtCache::new(&self.inner);
+
+        let encoded = self
+            .inner
+            .retrieve_encoded_subchunk(&subchunk_cache, &subchunk_indices)?;
+        Ok(encoded.map(|buf| PyBytes::new(buf.into())))
+    }
+
+    #[pyo3(signature = (subchunk_indices, **codec_options))]
+    fn retrieve_subchunk(
+        &self,
+        subchunk_indices: PyChunkIndices,
+        codec_options: Option<PyCodecOptions>,
+    ) -> ZarristaResult<DecodedArray> {
+        let codec_options = codec_options
+            .map(|opts| opts.into_inner())
+            .unwrap_or_default();
+
+        // TODO: allow user to manage shard cache
+        let subchunk_cache = ArrayShardedReadableExtCache::new(&self.inner);
+
+        Ok(self
+            .inner
+            .retrieve_subchunk_opt(&subchunk_cache, &subchunk_indices, &codec_options)?)
     }
 
     #[pyo3(signature = (chunk_indices, decoded_chunk, **codec_options))]
@@ -152,7 +181,7 @@ impl PyArray {
             .map(|opts| opts.into_inner())
             .unwrap_or_default();
         self.inner.store_chunk_opt(
-            chunk_indices.as_ref(),
+            &chunk_indices,
             decoded_chunk.as_array_bytes()?,
             &codec_options,
         )?;
@@ -168,7 +197,7 @@ impl PyArray {
         // The responsibility is on the caller to ensure the chunk is encoded correctly
         unsafe {
             self.inner
-                .store_encoded_chunk(chunk_indices.as_ref(), encoded_chunk.into_inner())?;
+                .store_encoded_chunk(&chunk_indices, encoded_chunk.into_inner())?;
         }
         Ok(())
     }

--- a/tests/array/test_subchunk.py
+++ b/tests/array/test_subchunk.py
@@ -1,0 +1,99 @@
+"""Reading individual subchunks (inner chunks) of a sharded array.
+
+`retrieve_subchunk` decodes one inner chunk of a shard; `retrieve_encoded_subchunk`
+returns its raw stored bytes. Subchunk indices address the subchunk grid, which
+spans the whole array (see `subchunk_grid_shape`).
+"""
+
+import numpy as np
+
+from zarrista import (
+    Array,
+    ArrayBuilder,
+    ArrayBytes,
+    ChunkGrid,
+    DataType,
+    FillValue,
+    Tensor,
+)
+from zarrista.store import MemoryStore
+
+
+def _sharded_array(store: MemoryStore | None = None) -> Array:
+    """A 4x4 int32 array: one 4x4 shard split into 2x2 subchunks (a 2x2 grid)."""
+    return (
+        ArrayBuilder(
+            ChunkGrid.regular([4, 4], [4, 4]),
+            DataType.from_string("int32"),
+            FillValue(b"\x00\x00\x00\x00"),
+        )
+        .subchunk_shape([2, 2])
+        .create(store if store is not None else MemoryStore(), "/a")
+    )
+
+
+def test_retrieve_subchunk_decodes_each_inner_chunk():
+    arr = _sharded_array()
+    data = np.arange(16, dtype="int32").reshape(4, 4)
+    arr.store_chunk([0, 0], ArrayBytes(data.tobytes()))
+
+    assert arr.is_sharded
+    assert arr.subchunk_grid_shape == [2, 2]
+
+    for r in range(2):
+        for c in range(2):
+            sub = arr.retrieve_subchunk([r, c])
+            assert isinstance(sub, Tensor)
+            expected = data[r * 2 : r * 2 + 2, c * 2 : c * 2 + 2]
+            np.testing.assert_array_equal(sub.to_numpy(), expected)
+
+
+def test_retrieve_encoded_subchunk_returns_raw_bytes():
+    arr = _sharded_array()
+    data = np.arange(16, dtype="int32").reshape(4, 4)
+    arr.store_chunk([0, 0], ArrayBytes(data.tobytes()))
+
+    # No compressor, so the encoded inner chunk is the raw little-endian data.
+    encoded = arr.retrieve_encoded_subchunk([1, 0])
+    assert encoded is not None
+    decoded = np.frombuffer(bytes(encoded), dtype="int32").reshape(2, 2)
+    np.testing.assert_array_equal(decoded, data[2:4, 0:2])
+
+
+def test_retrieve_encoded_subchunk_absent_is_none():
+    arr = _sharded_array()  # nothing written
+    assert arr.retrieve_encoded_subchunk([0, 0]) is None
+
+
+# --- async ---------------------------------------------------------------
+
+from obstore.store import LocalStore  # noqa: E402
+
+from zarrista import AsyncArray  # noqa: E402
+
+
+async def _async_sharded_array(tmp_path) -> AsyncArray:
+    return await (
+        ArrayBuilder(
+            ChunkGrid.regular([4, 4], [4, 4]),
+            DataType.from_string("int32"),
+            FillValue(b"\x00\x00\x00\x00"),
+        )
+        .subchunk_shape([2, 2])
+        .create_async(LocalStore(str(tmp_path)), "/a")
+    )
+
+
+async def test_async_retrieve_subchunk(tmp_path):
+    arr = await _async_sharded_array(tmp_path)
+    data = np.arange(16, dtype="int32").reshape(4, 4)
+    await arr.store_chunk([0, 0], ArrayBytes(data.tobytes()))
+
+    sub = await arr.retrieve_subchunk([1, 1])
+    assert isinstance(sub, Tensor)
+    np.testing.assert_array_equal(sub.to_numpy(), data[2:4, 2:4])
+
+    encoded = await arr.retrieve_encoded_subchunk([1, 1])
+    assert encoded is not None
+    decoded = np.frombuffer(bytes(encoded), dtype="int32").reshape(2, 2)
+    np.testing.assert_array_equal(decoded, data[2:4, 2:4])


### PR DESCRIPTION
Adds support for reading a single subchunk/shard.

For now, this ignores chunk caching. As a follow up we can consider the right user API to expose chunk caching. See [`ArrayShardedReadableExtCache`](https://docs.rs/zarrs/latest/zarrs/array/struct.ArrayShardedReadableExtCache.html)

Closes https://github.com/developmentseed/zarrista/issues/60