### PR TITLE
feat: Add erase_chunks method

### DIFF
--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -205,6 +205,22 @@ class Array:
 
         Erasing an absent chunk is a no-op.
         """
+    def erase_chunks(self, chunks: Selection) -> None:
+        """Delete the specified chunks from the store.
+
+        `chunks` is a numpy-style selection in **chunk-grid** coordinates, not
+        element coordinates.
+
+        On an array with chunk shape `(10, 10)`, `erase_chunks((0, slice(0, 2)))` erases
+        the two chunks covering elements `[0:10, 0:20]`.
+
+        An empty selection (`()` or `...`) erases every chunk.
+
+        For a sharded array the chunk grid is the shard grid, so whole shards are
+        erased.
+
+        Erasing absent chunks is a no-op.
+        """
     def erase_metadata(self) -> None:
         """Delete the array's metadata from the store."""
     def read_only(self) -> Array:
@@ -438,6 +454,22 @@ class AsyncArray:
         """Delete the chunk at `chunk_indices` from the store.
 
         Erasing an absent chunk is a no-op.
+        """
+    async def erase_chunks(self, chunks: Selection) -> None:
+        """Delete the specified chunks from the store.
+
+        `chunks` is a numpy-style selection in **chunk-grid** coordinates, not
+        element coordinates.
+
+        On an array with chunk shape `(10, 10)`, `erase_chunks((0, slice(0, 2)))` erases
+        the two chunks covering elements `[0:10, 0:20]`.
+
+        An empty selection (`()` or `...`) erases every chunk.
+
+        For a sharded array the chunk grid is the shard grid, so whole shards are
+        erased.
+
+        Erasing absent chunks is a no-op.
         """
     async def erase_metadata(self) -> None:
         """Delete the array's metadata from the store."""

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3_async_runtimes::tokio::future_into_py;
 use pyo3_bytes::PyBytes;
-use zarrs::array::{Array, AsyncArrayShardedReadableExt, AsyncArrayShardedReadableExtCache};
+use zarrs::array::{
+    Array, ArraySubset, AsyncArrayShardedReadableExt, AsyncArrayShardedReadableExtCache,
+};
 use zarrs::storage::AsyncReadableWritableListableStorageTraits;
 
 use crate::array::PyChunkIndices;
@@ -37,6 +39,16 @@ impl PyAsyncArray {
 
     pub fn inner(&self) -> &Arc<Array<dyn AsyncReadableWritableListableStorageTraits>> {
         &self.inner
+    }
+
+    /// Resolve a selection against the array's shape
+    fn array_subset(&self, selection: &PySelection) -> ZarristaResult<ArraySubset> {
+        selection.to_array_subset(self.inner.shape())
+    }
+
+    /// Resolve a selection against the array's **chunk grid** shape
+    fn chunk_grid_subset(&self, selection: &PySelection) -> ZarristaResult<ArraySubset> {
+        selection.to_array_subset(self.inner.chunk_grid_shape())
     }
 }
 
@@ -134,6 +146,22 @@ impl PyAsyncArray {
         })
     }
 
+    fn erase_chunks<'py>(
+        &self,
+        py: Python<'py>,
+        chunks: PySelection,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let chunks = self.chunk_grid_subset(&chunks)?;
+        let inner = self.inner.clone();
+        future_into_py(py, async move {
+            inner
+                .async_erase_chunks(&chunks)
+                .await
+                .map_err(ZarristaError::from)?;
+            Ok(())
+        })
+    }
+
     /// Return a read-only view of this array; writes raise at runtime.
     fn read_only(&self) -> Self {
         let read_list_storage = self.inner.storage().readable_listable();
@@ -162,7 +190,7 @@ impl PyAsyncArray {
         selection: PySelection,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
-        let array_subset = selection.to_array_subset(inner.shape())?;
+        let array_subset = self.array_subset(&selection)?;
 
         future_into_py(py, async move {
             let decoded = inner

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3_bytes::PyBytes;
-use zarrs::array::{Array, ArrayShardedReadableExt, ArrayShardedReadableExtCache};
+use zarrs::array::{Array, ArrayShardedReadableExt, ArrayShardedReadableExtCache, ArraySubset};
 use zarrs::storage::ReadableWritableListableStorageTraits;
 
 use crate::array::PyChunkIndices;
@@ -37,6 +37,16 @@ impl PyArray {
 
     pub fn inner(&self) -> &Arc<Array<dyn ReadableWritableListableStorageTraits>> {
         &self.inner
+    }
+
+    /// Resolve a selection against the array's shape
+    fn array_subset(&self, selection: &PySelection) -> ZarristaResult<ArraySubset> {
+        selection.to_array_subset(self.inner.shape())
+    }
+
+    /// Resolve a selection against the array's **chunk grid** shape
+    fn chunk_grid_subset(&self, selection: &PySelection) -> ZarristaResult<ArraySubset> {
+        selection.to_array_subset(self.inner.chunk_grid_shape())
     }
 }
 
@@ -103,6 +113,12 @@ impl PyArray {
         Ok(())
     }
 
+    fn erase_chunks(&self, chunks: PySelection) -> ZarristaResult<()> {
+        let chunks = self.chunk_grid_subset(&chunks)?;
+        self.inner.erase_chunks(&chunks)?;
+        Ok(())
+    }
+
     fn erase_metadata(&self) -> ZarristaResult<()> {
         self.inner.erase_metadata()?;
         Ok(())
@@ -122,7 +138,7 @@ impl PyArray {
     /// Returns one of the decoded result classes (`Tensor`, `VariableArray`,
     /// `MaskedTensor`, `MaskedVariableArray`) depending on the dtype layout.
     fn retrieve_array_subset(&self, selection: PySelection) -> ZarristaResult<DecodedArray> {
-        let array_subset = selection.to_array_subset(self.inner.shape())?;
+        let array_subset = self.array_subset(&selection)?;
         Ok(self.inner.retrieve_array_subset(&array_subset)?)
     }
 

--- a/tests/array/test_erase.py
+++ b/tests/array/test_erase.py
@@ -1,0 +1,229 @@
+"""`erase_chunks` deletes a region of the chunk grid.
+
+Its argument is a numpy-style selection in **chunk-grid** coordinates, not
+element coordinates, so it is resolved against `chunk_grid_shape` rather than
+`shape`. Both spaces are plain integer tuples and nothing but the shape used to
+resolve them tells the two apart, so these tests pin the distinction down.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+from numpy.typing import NDArray
+from obstore.store import LocalStore
+
+from zarrista import (
+    Array,
+    ArrayBuilder,
+    ArrayBytes,
+    AsyncArray,
+    ChunkGrid,
+    DataType,
+    FillValue,
+)
+from zarrista.store import MemoryStore
+
+# The contents of the 4x4 fixture: chunk (i, j) is filled with `1 + 2i + j`.
+FULL = np.array(
+    [
+        [1, 1, 2, 2],
+        [1, 1, 2, 2],
+        [3, 3, 4, 4],
+        [3, 3, 4, 4],
+    ],
+    dtype="int32",
+)
+EMPTY = np.zeros((4, 4), dtype="int32")
+
+
+def _chunked_array() -> Array:
+    """A 4x4 int32 array: a 2x2 grid of 2x2 chunks, each filled with `1 + 2i + j`."""
+    array = ArrayBuilder(
+        ChunkGrid.regular([4, 4], [2, 2]),
+        DataType.from_string("int32"),
+        FillValue(b"\x00\x00\x00\x00"),
+    ).create(MemoryStore(), "/a")
+    for i in (0, 1):
+        for j in (0, 1):
+            block = np.full((2, 2), 1 + 2 * i + j, dtype="int32")
+            array.store_chunk([i, j], ArrayBytes(block.tobytes()))
+    return array
+
+
+def _sharded_array() -> Array:
+    """An 8x8 int32 array: a 2x2 grid of 4x4 shards, each split into 2x2 subchunks."""
+    array = (
+        ArrayBuilder(
+            ChunkGrid.regular([8, 8], [4, 4]),
+            DataType.from_string("int32"),
+            FillValue(b"\x00\x00\x00\x00"),
+        )
+        .subchunk_shape([2, 2])
+        .create(MemoryStore(), "/a")
+    )
+    for i in (0, 1):
+        for j in (0, 1):
+            block = np.full((4, 4), 1 + 2 * i + j, dtype="int32")
+            array.store_chunk([i, j], ArrayBytes(block.tobytes()))
+    return array
+
+
+def test_erases_a_row_of_the_chunk_grid():
+    """Chunk index 0 covers elements 0:2, not element 0."""
+    array = _chunked_array()
+
+    array.erase_chunks((0, slice(None)))
+
+    expected = FULL.copy()
+    expected[0:2, :] = 0
+    np.testing.assert_array_equal(array[:, :].to_numpy(), expected)
+
+
+def test_erases_a_single_chunk():
+    array = _chunked_array()
+
+    array.erase_chunks((0, 1))
+
+    expected = FULL.copy()
+    expected[0:2, 2:4] = 0
+    np.testing.assert_array_equal(array[:, :].to_numpy(), expected)
+
+
+def test_negative_index_wraps_against_the_chunk_grid():
+    """-1 is the last *chunk* (elements 2:4); against the shape it would be a no-op."""
+    array = _chunked_array()
+
+    array.erase_chunks((-1, slice(None)))
+
+    expected = FULL.copy()
+    expected[2:4, :] = 0
+    np.testing.assert_array_equal(array[:, :].to_numpy(), expected)
+
+
+def test_ellipsis_erases_every_chunk():
+    array = _chunked_array()
+
+    array.erase_chunks(...)
+
+    np.testing.assert_array_equal(array[:, :].to_numpy(), EMPTY)
+
+
+def test_empty_tuple_erases_every_chunk():
+    array = _chunked_array()
+
+    array.erase_chunks(())
+
+    np.testing.assert_array_equal(array[:, :].to_numpy(), EMPTY)
+
+
+def test_erasing_absent_chunks_is_a_noop():
+    array = _chunked_array()
+    array.erase_chunks(...)
+
+    array.erase_chunks(...)
+
+    np.testing.assert_array_equal(array[:, :].to_numpy(), EMPTY)
+
+
+def test_index_beyond_the_chunk_grid_raises():
+    """3 is a valid element index for the (4, 4) array, but the grid is (2, 2)."""
+    array = _chunked_array()
+
+    with pytest.raises(IndexError, match="axis 0 with size 2"):
+        array.erase_chunks((3, 0))
+
+
+def test_a_rejected_selection_erases_nothing():
+    """The selection resolves before any chunk is deleted."""
+    array = _chunked_array()
+
+    with pytest.raises(IndexError):
+        array.erase_chunks((3, 0))
+
+    np.testing.assert_array_equal(array[:, :].to_numpy(), FULL)
+
+
+def test_strided_selection_is_rejected():
+    array = _chunked_array()
+
+    with pytest.raises(NotImplementedError, match="step other than 1"):
+        array.erase_chunks((slice(0, 2, 2), 0))
+
+
+def test_sharded_erases_a_whole_shard():
+    """The chunk grid of a sharded array is the shard grid."""
+    array = _sharded_array()
+
+    array.erase_chunks((0, 0))
+
+    np.testing.assert_array_equal(
+        array.retrieve_chunk([0, 0]).to_numpy(),
+        np.zeros((4, 4), dtype="int32"),
+    )
+
+
+def test_sharded_leaves_other_shards_intact():
+    array = _sharded_array()
+
+    array.erase_chunks((0, 0))
+
+    np.testing.assert_array_equal(
+        array.retrieve_chunk([0, 1]).to_numpy(),
+        np.full((4, 4), 2, dtype="int32"),
+    )
+
+
+def test_subchunk_index_beyond_the_shard_grid_raises():
+    """(0, 3) addresses the (4, 4) subchunk grid; the shard grid is (2, 2)."""
+    array = _sharded_array()
+
+    with pytest.raises(IndexError, match="axis 1 with size 2"):
+        array.erase_chunks((0, 3))
+
+
+# --- async ---------------------------------------------------------------
+
+
+async def _async_chunked_array(tmp_path: Path) -> AsyncArray:
+    """The same 4x4 / 2x2 fixture, written with zarr-python and opened async."""
+    path = tmp_path / "a.zarr"
+    z = zarr.create_array(
+        store=str(path),
+        shape=(4, 4),
+        chunks=(2, 2),
+        dtype="int32",
+        fill_value=0,
+    )
+    z[:] = FULL
+    return await AsyncArray.open_async(LocalStore(str(path)))
+
+
+async def _read_all(array: AsyncArray) -> NDArray[np.int32]:
+    return (await array[:, :]).to_numpy()
+
+
+async def test_async_erases_a_row_of_the_chunk_grid(tmp_path: Path):
+    array = await _async_chunked_array(tmp_path)
+
+    await array.erase_chunks((0, slice(None)))
+
+    expected = FULL.copy()
+    expected[0:2, :] = 0
+    np.testing.assert_array_equal(await _read_all(array), expected)
+
+
+async def test_async_ellipsis_erases_every_chunk(tmp_path: Path):
+    array = await _async_chunked_array(tmp_path)
+
+    await array.erase_chunks(...)
+
+    np.testing.assert_array_equal(await _read_all(array), EMPTY)
+
+
+async def test_async_index_beyond_the_chunk_grid_raises(tmp_path: Path):
+    array = await _async_chunked_array(tmp_path)
+
+    with pytest.raises(IndexError, match="axis 0 with size 2"):
+        await array.erase_chunks((3, 0))

--- a/tests/array/test_read_only.py
+++ b/tests/array/test_read_only.py
@@ -46,6 +46,12 @@ def test_read_only_erase_metadata_raises():
         ro.erase_metadata()
 
 
+def test_read_only_erase_chunks_raises():
+    ro = _writable_array().read_only()
+    with pytest.raises(ZarristaError, match="read only"):
+        ro.erase_chunks(...)
+
+
 def test_writable_array_still_writes():
     """The original array (and any non-read-only array) writes without error."""
     array = _writable_array()


### PR DESCRIPTION
Now I understand that the [`dyn ArraySubsetTraits` here](https://docs.rs/zarrs/latest/zarrs/array/struct.Array.html#method.erase_chunks) just means we can provide a selection over the chunk grid. 