### PR TITLE
fix: Release the GIL through a helper that compiles on wasm32

### DIFF
--- a/src/array/encoded_chunk.rs
+++ b/src/array/encoded_chunk.rs
@@ -92,7 +92,7 @@ impl PyEncodedChunk {
         py: Python,
         codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<DecodedArray> {
-        py.detach(|| {
+        crate::py::detach(py, || {
             let codec_options = codec_options
                 .map(|opts| opts.into_inner())
                 .unwrap_or_default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod exceptions;
 mod group;
 mod metadata;
 mod node;
+mod py;
 mod storage;
 mod thread_pool;
 mod wasm;

--- a/src/py.rs
+++ b/src/py.rs
@@ -1,0 +1,31 @@
+//! Helpers for the pyo3 boundary.
+
+/// Run `f` with the GIL released, and return its result.
+///
+/// Use this instead of [`pyo3::Python::detach`] for any closure that returns a
+/// zarrs-derived type. `Python::detach` bounds both the closure and its return
+/// type by `Ungil`, which implies `Send`. zarrs relaxes its `Send`/`Sync`
+/// bounds on `wasm32`, so a return type as ordinary as
+/// `ZarristaResult<DecodedArray>` does not satisfy that bound there:
+/// `ZarristaError` holds a `CodecError`, which holds a `DataType`, which is an
+/// `Arc<dyn DataTypeTraits>`.
+///
+/// On `wasm32` this runs `f` directly. That target is single-threaded, so there
+/// is no GIL contention to relieve and nothing is lost.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn detach<T, F>(py: pyo3::Python<'_>, f: F) -> T
+where
+    F: pyo3::marker::Ungil + FnOnce() -> T,
+    T: pyo3::marker::Ungil,
+{
+    py.detach(f)
+}
+
+/// See the native implementation for why `wasm32` runs `f` directly.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn detach<T, F>(_py: pyo3::Python<'_>, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    f()
+}


### PR DESCRIPTION
This was meant to merge along with #126 but I forgot that the emscripten CI check wasn't set to be required.

Below summary written by Claude:

---

Fixes the emscripten build on `main`, which is currently red after #126.

## The problem

`EncodedChunk.decode` calls `Python::detach` to release the GIL. That method bounds **both** the closure and its return type by `Ungil`, which implies `Send`:

```rust
pub fn detach<T, F>(self, f: F) -> T
where
    F: Ungil + FnOnce() -> T,
    T: Ungil,          // <-- this one
```

zarrs relaxes its `Send`/`Sync` bounds on `wasm32`, so `ZarristaResult<DecodedArray>` does not satisfy that bound there: `ZarristaError` holds a `CodecError`, which holds a `DataType`, which is an `Arc<dyn DataTypeTraits>`.

```
error[E0277]: `(dyn DataTypeTraits + 'static)` cannot be sent between threads safely
    --> src/array/encoded_chunk.rs:95:12
  95 |         py.detach(|| {
     |            ^^^^^^^
note: required because it appears within the type `error::ZarristaError`
note: required because it appears within the type `Result<DecodedArray, error::ZarristaError>`
```

`wasm_send_sync!` does not help here — the offending type is the closure's *return value*, not the `#[pyclass]`.

## The fix

A `detach` helper in a new `src/py.rs` that delegates to `Python::detach` natively, and runs the closure directly on `wasm32`. That target is single-threaded, so there is no GIL contention to relieve and nothing is lost.

It lives in `py.rs` rather than `wasm.rs` deliberately: the call site's intent is "release the GIL", and that the wasm arm differs is the helper's business. `wasm_send_sync!` stays in `wasm.rs`, because that macro really is wasm-specific.

This will carry weight for #124 — the GIL-release pass hits the same bound on every method returning a `ZarristaResult` of a zarrs-derived type, which is most of them.

## Verification

`cargo check --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`, and the full pytest suite (155 passed) are clean locally. The `wasm32` arm itself is only checkable in CI — `emcc` is not installed locally, and `cargo check --target wasm32-unknown-emscripten` cannot get past `pyo3-ffi`'s build script without the `PYO3_CONFIG_FILE` that maturin-action generates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)