### PR TITLE
feat: Make `retrieve_encoded_subchunk` return a `EncodedChunk` class, not raw bytes

### DIFF
--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -238,18 +238,33 @@ class Array:
         Raises:
             TypeError: If a keyword argument is not a known codec option.
         """
-    def retrieve_encoded_subchunk(self, subchunk_indices: list[int]) -> Buffer | None:
+    def retrieve_encoded_subchunk(
+        self,
+        subchunk_indices: list[int],
+    ) -> EncodedChunk | None:
         """Read the raw, still-encoded bytes of a subchunk of a sharded array.
 
-        The method returns the bytes without any change, and it does not run
-        the codec pipeline.
+        The method reads the bytes and does not run the codec pipeline. To
+        decode them, use [`EncodedChunk.decode`][zarrista.EncodedChunk.decode]
+        or
+        [`EncodedChunk.decode_async`][zarrista.EncodedChunk.decode_async]. The
+        returned chunk carries the codec chain for the subchunks, which is the
+        inner chain of the `sharding_indexed` codec.
+
+        The array must be **exclusively** sharded: the `sharding_indexed` codec
+        must be the only codec. An array-to-array codec before it, or a
+        bytes-to-bytes codec after it, re-encodes the shard, so no byte range of
+        the shard holds the bytes of one subchunk.
 
         Args:
             subchunk_indices: The position of the subchunk in the subchunk grid.
 
         Returns:
-            The encoded subchunk bytes, or `None` if the subchunk is absent from
-            the store.
+            The encoded subchunk, or `None` if the subchunk is absent from the
+            store.
+
+        Raises:
+            ArrayError: If the array is not exclusively sharded.
         """
     @property
     def store(self) -> FilesystemStore | MemoryStore:
@@ -723,18 +738,30 @@ class AsyncArray:
     async def retrieve_encoded_subchunk(
         self,
         subchunk_indices: list[int],
-    ) -> Buffer | None:
+    ) -> EncodedChunk | None:
         """Read the raw, still-encoded bytes of a subchunk of a sharded array.
 
-        The method returns the bytes without any change, and it does not run
-        the codec pipeline.
+        The method reads the bytes and does not run the codec pipeline. To
+        decode them, use [`EncodedChunk.decode`][zarrista.EncodedChunk.decode]
+        or
+        [`EncodedChunk.decode_async`][zarrista.EncodedChunk.decode_async]. The
+        returned chunk carries the codec chain for the subchunks, which is the
+        inner chain of the `sharding_indexed` codec.
+
+        The array must be **exclusively** sharded: the `sharding_indexed` codec
+        must be the only codec. An array-to-array codec before it, or a
+        bytes-to-bytes codec after it, re-encodes the shard, so no byte range of
+        the shard holds the bytes of one subchunk.
 
         Args:
             subchunk_indices: The position of the subchunk in the subchunk grid.
 
         Returns:
-            The encoded subchunk bytes, or `None` if the subchunk is absent from
-            the store.
+            The encoded subchunk, or `None` if the subchunk is absent from the
+            store.
+
+        Raises:
+            ArrayError: If the array is not exclusively sharded.
         """
     @property
     def store(self) -> AsyncStore:

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -6,7 +6,8 @@ use pyo3::prelude::*;
 use pyo3_async_runtimes::tokio::future_into_py;
 use pyo3_bytes::PyBytes;
 use zarrs::array::{
-    Array, ArraySubset, AsyncArrayShardedReadableExt, AsyncArrayShardedReadableExtCache,
+    Array, ArrayShardedExt, ArraySubset, AsyncArrayShardedReadableExt,
+    AsyncArrayShardedReadableExtCache,
 };
 use zarrs::storage::AsyncReadableWritableListableStorageTraits;
 
@@ -14,7 +15,7 @@ use crate::array::selection::PySelection;
 use crate::array::shared::shared_array_methods;
 use crate::array::{PyChunkIndices, PyEncodedChunk};
 use crate::array_bytes::PyArrayBytes;
-use crate::codec::PyCodecOptions;
+use crate::codec::{CodecChainSubchunkExt, PyCodecOptions};
 use crate::data::DecodedArray;
 use crate::error::{ZarristaError, ZarristaResult};
 use crate::metadata::PyArrayMetadata;
@@ -258,11 +259,30 @@ impl PyAsyncArray {
 
         let inner = self.inner.clone();
         future_into_py(py, async move {
-            let encoded = inner
+            let Some(encoded) = inner
                 .async_retrieve_encoded_subchunk(&subchunk_cache, &subchunk_indices)
                 .await
-                .map_err(ZarristaError::from)?;
-            Ok(encoded.map(|buf| PyBytes::new(buf.into())))
+                .map_err(ZarristaError::from)?
+            else {
+                return Ok(None);
+            };
+
+            let subchunk_codec_chain = inner
+                .codecs()
+                .subchunk_chain()?
+                .expect("zarrs already validated that the array is an exclusively sharded array");
+
+            let subchunk_shape = inner
+                .effective_subchunk_shape()
+                .expect("zarrs already validated that the array is an exclusively sharded array");
+
+            Ok(Some(PyEncodedChunk::new(
+                encoded.into(),
+                subchunk_codec_chain,
+                inner.data_type().clone(),
+                inner.fill_value().clone(),
+                subchunk_shape,
+            )))
         })
     }
 

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -267,14 +267,13 @@ impl PyAsyncArray {
                 return Ok(None);
             };
 
-            let subchunk_codec_chain = inner
-                .codecs()
-                .subchunk_chain()?
-                .expect("zarrs already validated that the array is an exclusively sharded array");
+            let subchunk_codec_chain = inner.codecs().subchunk_chain()?.expect(
+                "zarrs accepts only an exclusively sharded array, so the serializer shards",
+            );
 
             let subchunk_shape = inner
                 .effective_subchunk_shape()
-                .expect("zarrs already validated that the array is an exclusively sharded array");
+                .expect("an exclusively sharded array has no outer array-to-array codecs");
 
             Ok(Some(PyEncodedChunk::new(
                 encoded.into(),

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -4,14 +4,16 @@ use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3_bytes::PyBytes;
-use zarrs::array::{Array, ArrayShardedReadableExt, ArrayShardedReadableExtCache, ArraySubset};
+use zarrs::array::{
+    Array, ArrayShardedExt, ArrayShardedReadableExt, ArrayShardedReadableExtCache, ArraySubset,
+};
 use zarrs::storage::ReadableWritableListableStorageTraits;
 
 use crate::array::selection::PySelection;
 use crate::array::shared::shared_array_methods;
 use crate::array::{PyChunkIndices, PyEncodedChunk};
 use crate::array_bytes::PyArrayBytes;
-use crate::codec::PyCodecOptions;
+use crate::codec::{CodecChainSubchunkExt, PyCodecOptions};
 use crate::data::DecodedArray;
 use crate::error::ZarristaResult;
 use crate::metadata::PyArrayMetadata;
@@ -177,14 +179,35 @@ impl PyArray {
     fn retrieve_encoded_subchunk(
         &self,
         subchunk_indices: PyChunkIndices,
-    ) -> ZarristaResult<Option<PyBytes>> {
+    ) -> ZarristaResult<Option<PyEncodedChunk>> {
         // TODO: allow user to manage shard cache
         let subchunk_cache = ArrayShardedReadableExtCache::new(&self.inner);
 
-        let encoded = self
+        let Some(encoded) = self
             .inner
-            .retrieve_encoded_subchunk(&subchunk_cache, &subchunk_indices)?;
-        Ok(encoded.map(|buf| PyBytes::new(buf.into())))
+            .retrieve_encoded_subchunk(&subchunk_cache, &subchunk_indices)?
+        else {
+            return Ok(None);
+        };
+
+        let subchunk_codec_chain = self
+            .inner
+            .codecs()
+            .subchunk_chain()?
+            .expect("zarrs already validated that the array is an exclusively sharded array");
+
+        let subchunk_shape = self
+            .inner
+            .effective_subchunk_shape()
+            .expect("zarrs already validated that the array is an exclusively sharded array");
+
+        Ok(Some(PyEncodedChunk::new(
+            encoded.into(),
+            subchunk_codec_chain,
+            self.inner.data_type().clone(),
+            self.inner.fill_value().clone(),
+            subchunk_shape,
+        )))
     }
 
     #[pyo3(signature = (subchunk_indices, **codec_options))]

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -190,16 +190,15 @@ impl PyArray {
             return Ok(None);
         };
 
-        let subchunk_codec_chain = self
-            .inner
-            .codecs()
-            .subchunk_chain()?
-            .expect("zarrs already validated that the array is an exclusively sharded array");
+        let subchunk_codec_chain =
+            self.inner.codecs().subchunk_chain()?.expect(
+                "zarrs accepts only an exclusively sharded array, so the serializer shards",
+            );
 
         let subchunk_shape = self
             .inner
             .effective_subchunk_shape()
-            .expect("zarrs already validated that the array is an exclusively sharded array");
+            .expect("an exclusively sharded array has no outer array-to-array codecs");
 
         Ok(Some(PyEncodedChunk::new(
             encoded.into(),

--- a/src/codec/array_to_bytes/mod.rs
+++ b/src/codec/array_to_bytes/mod.rs
@@ -1,7 +1,9 @@
 //! Array to bytes codecs, or "serializers".
 
 pub use codec_chain::PyCodecChain;
+pub(crate) use subchunk::CodecChainSubchunkExt;
 mod codec_chain;
+mod subchunk;
 
 use std::borrow::Cow;
 use std::sync::Arc;

--- a/src/codec/array_to_bytes/subchunk.rs
+++ b/src/codec/array_to_bytes/subchunk.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+
+use pyo3::exceptions::PyValueError;
+pub use pyo3::prelude::*;
+use zarrs::array::codec::ShardingCodecConfiguration;
+use zarrs::array::codec::array_to_bytes::sharding::ShardingCodec;
+use zarrs::array::{ArrayToBytesCodecTraits, CodecChain};
+use zarrs::metadata::ConfigurationSerialize;
+
+use crate::error::ZarristaResult;
+
+/// Subchunk behaviour for [`CodecChain`].
+pub(crate) trait CodecChainSubchunkExt {
+    /// Derive the codec chain that decodes one subchunk of this chain.
+    ///
+    /// Returns `None` if the serializer is not a `sharding_indexed` codec. Such
+    /// a chain has no subchunk level.
+    ///
+    /// The bytes of a subchunk are the output of the sharding codec's inner
+    /// chain. To decode subchunk bytes back to array values:
+    ///
+    /// - reverse that inner subchunk chain
+    /// - then reverse the outer array-to-array codecs, which ran before
+    ///   sharding.
+    ///
+    /// The outer bytes-to-bytes codecs are absent by design. They encode the
+    /// whole shard, not one subchunk.
+    ///
+    /// The rule is self-similar. Applied to its own output, it gives the next
+    /// level down for a nested shard.
+    fn subchunk_chain(&self) -> ZarristaResult<Option<Arc<CodecChain>>>;
+}
+
+impl CodecChainSubchunkExt for CodecChain {
+    fn subchunk_chain(&self) -> ZarristaResult<Option<Arc<CodecChain>>> {
+        let Some(inner) = sharding_inner_codecs(&**self.array_to_bytes_codec())? else {
+            return Ok(None);
+        };
+
+        let filters = self
+            .array_to_array_codecs()
+            .iter()
+            .chain(inner.array_to_array_codecs())
+            .cloned()
+            .collect();
+
+        Ok(Some(Arc::new(CodecChain::new(
+            filters,
+            inner.array_to_bytes_codec().clone(),
+            inner.bytes_to_bytes_codecs().to_vec(),
+        ))))
+    }
+}
+
+/// Access the inner codec chain of a `sharding_indexed` codec.
+///
+/// Returns `None` if `serializer` is not a `sharding_indexed` codec.
+///
+/// Ideally upstream will expose ShardingCodec::inner_codecs directly:
+/// <https://github.com/zarrs/zarrs/issues/438>
+pub(crate) fn sharding_inner_codecs(
+    serializer: &dyn ArrayToBytesCodecTraits,
+) -> ZarristaResult<Option<Arc<CodecChain>>> {
+    if !serializer.as_any().is::<ShardingCodec>() {
+        return Ok(None);
+    }
+
+    let configuration = serializer
+        .configuration_v3(&Default::default())
+        .expect("a sharding codec always has a configuration");
+    let ShardingCodecConfiguration::V1(sharding) =
+        ShardingCodecConfiguration::try_from_configuration(configuration).map_err(|err| {
+            PyValueError::new_err(format!("could not read the sharding configuration: {err}"))
+        })?
+    else {
+        // Only V1 exists today, and the array would not have opened if the
+        // codec had failed to build. Degrade to "not sharded".
+        return Ok(None);
+    };
+
+    Ok(Some(Arc::new(CodecChain::from_metadata(&sharding.codecs)?)))
+}

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -4,6 +4,7 @@ mod bytes_to_bytes;
 mod options;
 
 pub use array_to_array::{PyArrayToArrayCodec, bitround, transpose};
+pub(crate) use array_to_bytes::CodecChainSubchunkExt;
 pub use array_to_bytes::{PyArrayToBytesCodec, PyCodecChain};
 pub use bytes_to_bytes::PyBytesToBytesCodec;
 pub use bytes_to_bytes::blosc::blosc;

--- a/tests/array/test_subchunk.py
+++ b/tests/array/test_subchunk.py
@@ -1,41 +1,69 @@
 """Reading individual subchunks (inner chunks) of a sharded array.
 
-`retrieve_subchunk` decodes one inner chunk of a shard; `retrieve_encoded_subchunk`
-returns its raw stored bytes. Subchunk indices address the subchunk grid, which
-spans the whole array (see `subchunk_grid_shape`).
+`retrieve_subchunk` decodes one inner chunk of a shard. `retrieve_encoded_subchunk`
+returns its stored bytes as an `EncodedChunk`, paired with the codec chain that
+decodes them. Subchunk indices address the subchunk grid, which spans the whole
+array (see `subchunk_grid_shape`).
 """
 
+import copy
+
 import numpy as np
+import pytest
+from obstore.store import LocalStore
 
 from zarrista import (
     Array,
     ArrayBuilder,
     ArrayBytes,
+    AsyncArray,
     ChunkGrid,
     DataType,
+    EncodedChunk,
     FillValue,
     Tensor,
+    codec,
 )
+from zarrista.exceptions import ArrayError
 from zarrista.store import MemoryStore
 
+DATA = np.arange(16, dtype="int32").reshape(4, 4)
 
-def _sharded_array(store: MemoryStore | None = None) -> Array:
+
+def _builder(*, compressed: bool = False) -> ArrayBuilder:
     """A 4x4 int32 array: one 4x4 shard split into 2x2 subchunks (a 2x2 grid)."""
-    return (
-        ArrayBuilder(
-            ChunkGrid.regular([4, 4], [4, 4]),
-            DataType.from_string("int32"),
-            FillValue(b"\x00\x00\x00\x00"),
-        )
-        .subchunk_shape([2, 2])
-        .create(store if store is not None else MemoryStore(), "/a")
-    )
+    builder = ArrayBuilder(
+        ChunkGrid.regular([4, 4], [4, 4]),
+        DataType.from_string("int32"),
+        FillValue(b"\x00\x00\x00\x00"),
+    ).subchunk_shape([2, 2])
+    if compressed:
+        # The builder nests codecs inside the sharding codec, so this compresses
+        # each subchunk and leaves the array exclusively sharded.
+        builder = builder.compressors([codec.zstd(3, checksum=False)])
+    return builder
+
+
+def _sharded_array(*, compressed: bool = False, written: bool = True) -> Array:
+    arr = _builder(compressed=compressed).create(MemoryStore(), "/a")
+    if written:
+        arr.store_chunk([0, 0], ArrayBytes(DATA.tobytes()))
+    return arr
+
+
+def _encoded(arr: Array, subchunk_indices: list[int]) -> EncodedChunk:
+    """The encoded subchunk, which the caller knows is present."""
+    chunk = arr.retrieve_encoded_subchunk(subchunk_indices)
+    assert chunk is not None
+    return chunk
+
+
+def _expected(r: int, c: int) -> np.ndarray:
+    return DATA[r * 2 : r * 2 + 2, c * 2 : c * 2 + 2]
 
 
 def test_retrieve_subchunk_decodes_each_inner_chunk():
     arr = _sharded_array()
-    data = np.arange(16, dtype="int32").reshape(4, 4)
-    arr.store_chunk([0, 0], ArrayBytes(data.tobytes()))
 
     assert arr.is_sharded
     assert arr.subchunk_grid_shape == [2, 2]
@@ -44,56 +72,133 @@ def test_retrieve_subchunk_decodes_each_inner_chunk():
         for c in range(2):
             sub = arr.retrieve_subchunk([r, c])
             assert isinstance(sub, Tensor)
-            expected = data[r * 2 : r * 2 + 2, c * 2 : c * 2 + 2]
-            np.testing.assert_array_equal(sub.to_numpy(), expected)
+            np.testing.assert_array_equal(sub.to_numpy(), _expected(r, c))
 
 
-def test_retrieve_encoded_subchunk_returns_raw_bytes():
-    arr = _sharded_array()
-    data = np.arange(16, dtype="int32").reshape(4, 4)
-    arr.store_chunk([0, 0], ArrayBytes(data.tobytes()))
+def test_retrieve_encoded_subchunk_returns_an_encoded_chunk():
+    chunk = _encoded(_sharded_array(), [1, 0])
 
+    assert isinstance(chunk, EncodedChunk)
+    # The subchunk shape, not the shard shape.
+    assert chunk.shape == [2, 2]
+    assert chunk.data_type == DataType.from_string("int32")
     # No compressor, so the encoded inner chunk is the raw little-endian data.
-    encoded = arr.retrieve_encoded_subchunk([1, 0])
-    assert encoded is not None
-    decoded = np.frombuffer(bytes(encoded), dtype="int32").reshape(2, 2)
-    np.testing.assert_array_equal(decoded, data[2:4, 0:2])
+    assert len(chunk.buffer) == 16
 
 
-def test_retrieve_encoded_subchunk_absent_is_none():
-    arr = _sharded_array()  # nothing written
+def test_decode_matches_retrieve_subchunk():
+    arr = _sharded_array()
+
+    for r in range(2):
+        for c in range(2):
+            decoded = _encoded(arr, [r, c]).decode()
+            np.testing.assert_array_equal(np.asarray(decoded), _expected(r, c))
+            np.testing.assert_array_equal(
+                np.asarray(decoded),
+                np.asarray(arr.retrieve_subchunk([r, c])),
+            )
+
+
+def test_decode_runs_the_subchunk_codec_chain():
+    """A compressed subchunk decodes correctly, so the inner chain is applied."""
+    arr = _sharded_array(compressed=True)
+    chunk = _encoded(arr, [1, 1])
+
+    # zstd changes the size, so these are not the raw 16 bytes.
+    assert len(chunk.buffer) != 16
+    np.testing.assert_array_equal(np.asarray(chunk.decode()), _expected(1, 1))
+
+
+def test_codecs_is_the_subchunk_chain_not_the_array_chain():
+    """The chain decodes one subchunk, so it is the sharding codec's inner chain."""
+    arr = _sharded_array(compressed=True)
+
+    assert arr.codecs.serializer.name == "sharding_indexed"
+
+    chunk = _encoded(arr, [0, 0])
+    assert chunk.codecs.serializer.name == "bytes"
+    assert [c.name for c in chunk.codecs.compressors] == ["zstd"]
+
+
+def test_absent_subchunk_is_none():
+    arr = _sharded_array(written=False)
+
     assert arr.retrieve_encoded_subchunk([0, 0]) is None
+
+
+def test_decode_accepts_codec_options():
+    chunk = _encoded(_sharded_array(compressed=True), [0, 1])
+
+    decoded = chunk.decode(validate_checksums=False)
+
+    np.testing.assert_array_equal(np.asarray(decoded), _expected(0, 1))
+
+
+def _array_with_outer_codec(codecs: list) -> Array:
+    """An array whose sharding codec is not the only codec.
+
+    `ArrayBuilder` nests codecs inside the sharding codec, so it cannot build
+    one of these. Write the metadata by hand instead.
+    """
+    metadata = copy.deepcopy(_sharded_array(written=False).metadata)
+    metadata["codecs"] = codecs
+    arr = Array.from_metadata(metadata, MemoryStore(), "/a")
+    arr.store_metadata()
+    arr.store_chunk([0, 0], ArrayBytes(DATA.tobytes()))
+    return arr
+
+
+@pytest.mark.parametrize("position", ["filter", "compressor"])
+def test_not_exclusively_sharded_raises(position: str):
+    """Only an exclusively sharded array has byte ranges that hold one subchunk.
+
+    A codec outside the sharding codec re-encodes the whole shard, so no byte
+    range of the shard holds the bytes of one subchunk.
+    """
+    sharding = copy.deepcopy(_sharded_array(written=False).metadata["codecs"])
+    codecs = (
+        [{"name": "transpose", "configuration": {"order": [1, 0]}}, *sharding]
+        if position == "filter"
+        else [*sharding, {"name": "crc32c"}]
+    )
+    arr = _array_with_outer_codec(codecs)
+
+    assert arr.is_sharded
+    with pytest.raises(ArrayError, match="not exclusively sharded"):
+        arr.retrieve_encoded_subchunk([0, 0])
 
 
 # --- async ---------------------------------------------------------------
 
-from obstore.store import LocalStore  # noqa: E402
-
-from zarrista import AsyncArray  # noqa: E402
-
 
 async def _async_sharded_array(tmp_path) -> AsyncArray:
-    return await (
-        ArrayBuilder(
-            ChunkGrid.regular([4, 4], [4, 4]),
-            DataType.from_string("int32"),
-            FillValue(b"\x00\x00\x00\x00"),
-        )
-        .subchunk_shape([2, 2])
-        .create_async(LocalStore(str(tmp_path)), "/a")
-    )
+    arr = await _builder().create_async(LocalStore(str(tmp_path)), "/a")
+    await arr.store_chunk([0, 0], ArrayBytes(DATA.tobytes()))
+    return arr
 
 
 async def test_async_retrieve_subchunk(tmp_path):
     arr = await _async_sharded_array(tmp_path)
-    data = np.arange(16, dtype="int32").reshape(4, 4)
-    await arr.store_chunk([0, 0], ArrayBytes(data.tobytes()))
 
     sub = await arr.retrieve_subchunk([1, 1])
     assert isinstance(sub, Tensor)
-    np.testing.assert_array_equal(sub.to_numpy(), data[2:4, 2:4])
+    np.testing.assert_array_equal(sub.to_numpy(), _expected(1, 1))
 
-    encoded = await arr.retrieve_encoded_subchunk([1, 1])
-    assert encoded is not None
-    decoded = np.frombuffer(bytes(encoded), dtype="int32").reshape(2, 2)
-    np.testing.assert_array_equal(decoded, data[2:4, 2:4])
+
+async def test_async_retrieve_encoded_subchunk(tmp_path):
+    arr = await _async_sharded_array(tmp_path)
+
+    chunk = await arr.retrieve_encoded_subchunk([1, 1])
+
+    assert isinstance(chunk, EncodedChunk)
+    assert chunk.shape == [2, 2]
+    np.testing.assert_array_equal(
+        np.asarray(await chunk.decode_async()),
+        _expected(1, 1),
+    )
+
+
+async def test_async_absent_subchunk_is_none(tmp_path):
+    arr = await _builder().create_async(LocalStore(str(tmp_path)), "/a")
+
+    assert await arr.retrieve_encoded_subchunk([0, 0]) is None


### PR DESCRIPTION
Follow up from https://github.com/developmentseed/zarrista/pull/126 to handle sharded reads, not just full-chunk reads.

So now a user should be able to do
```py
encoded_chunk = array.retrieve_encoded_subchunk(...)
data = encoded_chunk.decode(...)
```

The key is that we rewrite the inner codec chain of the `EncodedChunk` to refer only to the sharding codec's inner codecs, not the full array's codecs

This will error on any array that isn't [_exclusively sharded_](https://docs.rs/zarrs/latest/zarrs/array/trait.ArrayShardedExt.html#tymethod.is_exclusively_sharded). That is, if the arary has any array-to-array or bytes-to-bytes codecs, it will error.

