### PR TITLE
feat: Handle DLPack input when writing array chunks

### DIFF
--- a/docs/api/array.md
+++ b/docs/api/array.md
@@ -7,3 +7,7 @@
 ::: zarrista.AsyncArray
     options:
       show_bases: false
+
+## Types
+
+::: zarrista._array.DataInput

--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -308,10 +308,7 @@ class Array:
         updates, and rewrites each chunk that the region touches, so a write
         that covers whole chunks is cheaper than one that covers parts of them.
 
-        `data` may be anything that
-        [`DataInput`][zarrista.DataInput] accepts. An object that supports
-        DLPack, such as a numpy array, is checked against the array's data type
-        and against the shape of the selected region.
+        `data` may be any type allowed by `DataInput`.
 
         Args:
             selection: The region to write, in element coordinates.
@@ -840,10 +837,7 @@ class AsyncArray:
         updates, and rewrites each chunk that the region touches, so a write
         that covers whole chunks is cheaper than one that covers parts of them.
 
-        `data` may be anything that
-        [`DataInput`][zarrista.DataInput] accepts. An object that supports
-        DLPack, such as a numpy array, is checked against the array's data type
-        and against the shape of the selected region.
+        `data` may be any type allowed by `DataInput`.
 
         Args:
             selection: The region to write, in element coordinates.

--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Buffer
 from types import EllipsisType
-from typing import TypeAlias, Unpack
+from typing import Protocol, TypeAlias, Unpack
 
 from zarr_metadata import JSONValue, ZarrV3ArrayMetadataJSON
 
@@ -25,6 +25,33 @@ indices and slice bounds are normalized.
 
 The following are not supported: a slice with a step that is not 1, `None` (also
 called `np.newaxis`), boolean indexing, and fancy or array indexing.
+"""
+
+class SupportsDLPack(Protocol):
+    """An object that exports its data through the DLPack protocol.
+
+    numpy arrays, PyTorch tensors, JAX arrays, and CuPy arrays all satisfy this.
+
+    !!! warning "Not importable at runtime"
+
+        To use this type hint in your code, import it within a `TYPE_CHECKING`
+        block.
+    """
+
+    def __dlpack__(self, **kwargs: object) -> object: ...
+    def __dlpack_device__(self) -> tuple[int, int]: ...
+
+DataInput: TypeAlias = SupportsDLPack | ArrayBytes | Buffer
+"""In-memory array-like data that can be written to a Zarr Array/AsyncArray.
+
+Prefer rich types such as numpy arrays or anything that supports the DLPack interface.
+These allow richer validation. Passing a plain buffer will skip any data type or shape
+validation.
+
+!!! warning "Not importable at runtime"
+
+    To use this type hint in your code, import it within a `TYPE_CHECKING`
+    block.
 """
 
 class Array:
@@ -269,6 +296,41 @@ class Array:
     @property
     def store(self) -> FilesystemStore | MemoryStore:
         """Retrieve the store backing this array."""
+    def store_array_subset(
+        self,
+        selection: Selection,
+        data: DataInput,
+        **codec_options: Unpack[CodecOptions],
+    ) -> None:
+        """Encode `data` and write it to the region selected by `selection`.
+
+        The region does not have to align with the chunk grid. zarrista reads,
+        updates, and rewrites each chunk that the region touches, so a write
+        that covers whole chunks is cheaper than one that covers parts of them.
+
+        `data` may be anything that
+        [`DataInput`][zarrista.DataInput] accepts. An object that supports
+        DLPack, such as a numpy array, is checked against the array's data type
+        and against the shape of the selected region.
+
+        Args:
+            selection: The region to write, in element coordinates.
+            data: The data to write.
+            **codec_options: The codec options, as
+                [`CodecOptions`][zarrista.codec.CodecOptions].
+
+        Raises:
+            TypeError: If `data` has a different data type from the array, or if
+                a keyword argument is not a known codec option.
+            ValueError: If `data` has a different shape from the selected
+                region, or if it is not C-contiguous.
+            NotImplementedError: If `selection` uses a slice with a step that is
+                not 1, or if it uses `None` (`np.newaxis`).
+            IndexError: If `selection` has more entries than the array has
+                dimensions.
+            ArrayError: If the array is read-only, or if the size of `data` does
+                not match the selected region.
+        """
     def store_chunk(
         self,
         chunk_indices: list[int],
@@ -766,6 +828,41 @@ class AsyncArray:
     @property
     def store(self) -> AsyncStore:
         """Retrieve the store backing this array."""
+    async def store_array_subset(
+        self,
+        selection: Selection,
+        data: DataInput,
+        **codec_options: Unpack[CodecOptions],
+    ) -> None:
+        """Encode `data` and write it to the region selected by `selection`.
+
+        The region does not have to align with the chunk grid. zarrista reads,
+        updates, and rewrites each chunk that the region touches, so a write
+        that covers whole chunks is cheaper than one that covers parts of them.
+
+        `data` may be anything that
+        [`DataInput`][zarrista.DataInput] accepts. An object that supports
+        DLPack, such as a numpy array, is checked against the array's data type
+        and against the shape of the selected region.
+
+        Args:
+            selection: The region to write, in element coordinates.
+            data: The data to write.
+            **codec_options: The codec options, as
+                [`CodecOptions`][zarrista.codec.CodecOptions].
+
+        Raises:
+            TypeError: If `data` has a different data type from the array, or if
+                a keyword argument is not a known codec option.
+            ValueError: If `data` has a different shape from the selected
+                region, or if it is not C-contiguous.
+            NotImplementedError: If `selection` uses a slice with a step that is
+                not 1, or if it uses `None` (`np.newaxis`).
+            IndexError: If `selection` has more entries than the array has
+                dimensions.
+            ArrayError: If the array is read-only, or if the size of `data` does
+                not match the selected region.
+        """
     async def store_chunk(
         self,
         chunk_indices: list[int],

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -16,7 +16,7 @@ use crate::array::shared::shared_array_methods;
 use crate::array::{PyChunkIndices, PyEncodedChunk};
 use crate::array_bytes::PyArrayBytes;
 use crate::codec::{CodecChainSubchunkExt, PyCodecOptions};
-use crate::data::DecodedArray;
+use crate::data::{DecodedArray, PyDataInput};
 use crate::error::{ZarristaError, ZarristaResult};
 use crate::metadata::PyArrayMetadata;
 use crate::node::PyNodePath;
@@ -316,6 +316,33 @@ impl PyAsyncArray {
     #[getter]
     fn store(&self) -> &PyAsyncStorage {
         &self.store
+    }
+
+    #[pyo3(signature = (selection, data, **codec_options))]
+    fn store_array_subset<'py>(
+        &self,
+        py: Python<'py>,
+        selection: PySelection,
+        data: PyDataInput,
+        codec_options: Option<PyCodecOptions>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        let codec_options = codec_options
+            .map(|opts| opts.into_inner())
+            .unwrap_or_default();
+
+        let array_subset = self.array_subset(&selection)?;
+
+        future_into_py(py, async move {
+            let subset_data = data.as_array_bytes(inner.data_type(), array_subset.shape())?;
+
+            inner
+                .async_store_array_subset_opt(&array_subset, subset_data, &codec_options)
+                .await
+                .map_err(ZarristaError::from)?;
+
+            Ok(())
+        })
     }
 
     #[pyo3(signature = (chunk_indices, decoded_chunk, **codec_options))]

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -14,7 +14,7 @@ use crate::array::shared::shared_array_methods;
 use crate::array::{PyChunkIndices, PyEncodedChunk};
 use crate::array_bytes::PyArrayBytes;
 use crate::codec::{CodecChainSubchunkExt, PyCodecOptions};
-use crate::data::DecodedArray;
+use crate::data::{DecodedArray, PyDataInput};
 use crate::error::ZarristaResult;
 use crate::metadata::PyArrayMetadata;
 use crate::node::PyNodePath;
@@ -230,6 +230,23 @@ impl PyArray {
     #[getter]
     fn store(&self) -> PySyncStorage {
         self.store.clone()
+    }
+
+    #[pyo3(signature = (selection, data, **codec_options))]
+    fn store_array_subset(
+        &self,
+        selection: PySelection,
+        data: PyDataInput,
+        codec_options: Option<PyCodecOptions>,
+    ) -> ZarristaResult<()> {
+        let codec_options = codec_options
+            .map(|opts| opts.into_inner())
+            .unwrap_or_default();
+        let array_subset = self.array_subset(&selection)?;
+        let subset_data = data.as_array_bytes(self.inner.data_type(), array_subset.shape())?;
+        self.inner
+            .store_array_subset_opt(&array_subset, subset_data, &codec_options)?;
+        Ok(())
     }
 
     #[pyo3(signature = (chunk_indices, decoded_chunk, **codec_options))]

--- a/src/data/dlpack.rs
+++ b/src/data/dlpack.rs
@@ -1,11 +1,18 @@
 use std::ffi::c_void;
 
-use dlpark::ffi::{DLDataType, DLDataTypeCode, DLDevice, DLDeviceType};
+use dlpark::ManagedBox;
+use dlpark::ffi::{
+    DLDataType, DLDataTypeCode, DLDevice, DLDeviceType, DLManagedTensorVersioned,
+    DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION, DLTensor,
+};
 use dlpark::metadata::CopiedSlice;
+use dlpark::python::device::dlpack_device;
 use dlpark::{Builder, legacy};
 use pyo3::exceptions::PyValueError;
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use zarrs::array::DataType;
 
 use crate::data::PyTensor;
 use crate::error::ZarristaResult;
@@ -19,7 +26,8 @@ impl PyTensor {
         &self,
         _kwargs: Option<Bound<'py, PyDict>>,
     ) -> ZarristaResult<legacy::Dlpack> {
-        let dlpack_dtype = self.dlpack_data_type()?;
+        let dlpack_dtype = DLDataType::from_zarrs_data_type(&self.data_type)?;
+
         let shape = self
             .shape
             .iter()
@@ -61,45 +69,6 @@ impl PyTensor {
     }
 }
 
-impl PyTensor {
-    /// The DLPack element descriptor for this tensor's zarr data type.
-    fn dlpack_data_type(&self) -> ZarristaResult<DLDataType> {
-        use zarrs::array::data_type::*;
-
-        let dtype = &self.data_type;
-        let (code, bits) = if dtype.is::<BoolDataType>() {
-            (DLDataTypeCode::BOOL, 8)
-        } else if dtype.is::<Int8DataType>() {
-            (DLDataTypeCode::INT, 8)
-        } else if dtype.is::<Int16DataType>() {
-            (DLDataTypeCode::INT, 16)
-        } else if dtype.is::<Int32DataType>() {
-            (DLDataTypeCode::INT, 32)
-        } else if dtype.is::<Int64DataType>() {
-            (DLDataTypeCode::INT, 64)
-        } else if dtype.is::<UInt8DataType>() {
-            (DLDataTypeCode::UINT, 8)
-        } else if dtype.is::<UInt16DataType>() {
-            (DLDataTypeCode::UINT, 16)
-        } else if dtype.is::<UInt32DataType>() {
-            (DLDataTypeCode::UINT, 32)
-        } else if dtype.is::<UInt64DataType>() {
-            (DLDataTypeCode::UINT, 64)
-        } else if dtype.is::<Float16DataType>() {
-            (DLDataTypeCode::FLOAT, 16)
-        } else if dtype.is::<Float32DataType>() {
-            (DLDataTypeCode::FLOAT, 32)
-        } else if dtype.is::<Float64DataType>() {
-            (DLDataTypeCode::FLOAT, 64)
-        } else if dtype.is::<BFloat16DataType>() {
-            (DLDataTypeCode::BFLOAT, 16)
-        } else {
-            return Err(PyValueError::new_err("Unsupported data type in dlpack").into());
-        };
-        Ok(DLDataType::scalar(code, bits))
-    }
-}
-
 /// Strides, in elements, for a row-major contiguous buffer of the given shape.
 fn row_major_compact_strides(shape: &[i64]) -> Vec<i64> {
     let mut strides = vec![1; shape.len()];
@@ -107,4 +76,93 @@ fn row_major_compact_strides(shape: &[i64]) -> Vec<i64> {
         strides[axis] = strides[axis + 1] * shape[axis + 1];
     }
     strides
+}
+
+pub trait DLPackDataTypeExt {
+    /// Convert from DLPack data type to Zarr data type.
+    fn zarrs_data_type(&self) -> ZarristaResult<DataType>;
+
+    // Convert from Zarr data type to DLPack data type
+    fn from_zarrs_data_type(data_type: &DataType) -> ZarristaResult<Self>
+    where
+        Self: Sized;
+}
+
+impl DLPackDataTypeExt for DLDataType {
+    fn zarrs_data_type(&self) -> ZarristaResult<DataType> {
+        use zarrs::array::data_type::*;
+
+        if self.lanes != 1 {
+            return Err(PyValueError::new_err(format!(
+                "the data has {} lanes per element, but only scalar elements are supported",
+                self.lanes
+            ))
+            .into());
+        }
+
+        let data_type = match (self.code, self.bits) {
+            (DLDataTypeCode::BOOL, 8) => DataType::new(BoolDataType),
+            (DLDataTypeCode::INT, 8) => DataType::new(Int8DataType),
+            (DLDataTypeCode::INT, 16) => DataType::new(Int16DataType),
+            (DLDataTypeCode::INT, 32) => DataType::new(Int32DataType),
+            (DLDataTypeCode::INT, 64) => DataType::new(Int64DataType),
+            (DLDataTypeCode::UINT, 8) => DataType::new(UInt8DataType),
+            (DLDataTypeCode::UINT, 16) => DataType::new(UInt16DataType),
+            (DLDataTypeCode::UINT, 32) => DataType::new(UInt32DataType),
+            (DLDataTypeCode::UINT, 64) => DataType::new(UInt64DataType),
+            (DLDataTypeCode::FLOAT, 16) => DataType::new(Float16DataType),
+            (DLDataTypeCode::FLOAT, 32) => DataType::new(Float32DataType),
+            (DLDataTypeCode::FLOAT, 64) => DataType::new(Float64DataType),
+            (DLDataTypeCode::BFLOAT, 16) => DataType::new(BFloat16DataType),
+            (code, bits) => {
+                return Err(PyValueError::new_err(format!(
+                    "the data has DLPack type code {} at {bits} bits, \
+                 which has no Zarr data type",
+                    code.0
+                ))
+                .into());
+            }
+        };
+
+        Ok(data_type)
+    }
+
+    fn from_zarrs_data_type(data_type: &DataType) -> ZarristaResult<Self>
+    where
+        Self: Sized,
+    {
+        use zarrs::array::data_type::*;
+
+        let (code, bits) = if data_type.is::<BoolDataType>() {
+            (DLDataTypeCode::BOOL, 8)
+        } else if data_type.is::<Int8DataType>() {
+            (DLDataTypeCode::INT, 8)
+        } else if data_type.is::<Int16DataType>() {
+            (DLDataTypeCode::INT, 16)
+        } else if data_type.is::<Int32DataType>() {
+            (DLDataTypeCode::INT, 32)
+        } else if data_type.is::<Int64DataType>() {
+            (DLDataTypeCode::INT, 64)
+        } else if data_type.is::<UInt8DataType>() {
+            (DLDataTypeCode::UINT, 8)
+        } else if data_type.is::<UInt16DataType>() {
+            (DLDataTypeCode::UINT, 16)
+        } else if data_type.is::<UInt32DataType>() {
+            (DLDataTypeCode::UINT, 32)
+        } else if data_type.is::<UInt64DataType>() {
+            (DLDataTypeCode::UINT, 64)
+        } else if data_type.is::<Float16DataType>() {
+            (DLDataTypeCode::FLOAT, 16)
+        } else if data_type.is::<Float32DataType>() {
+            (DLDataTypeCode::FLOAT, 32)
+        } else if data_type.is::<Float64DataType>() {
+            (DLDataTypeCode::FLOAT, 64)
+        } else if data_type.is::<BFloat16DataType>() {
+            (DLDataTypeCode::BFLOAT, 16)
+        } else {
+            return Err(PyValueError::new_err("Unsupported data type in dlpack").into());
+        };
+
+        Ok(DLDataType::scalar(code, bits))
+    }
 }

--- a/src/data/dlpack.rs
+++ b/src/data/dlpack.rs
@@ -180,7 +180,7 @@ unsafe impl Send for PyManagedTensor {}
 
 impl PyManagedTensor {
     /// The DLPack tensor description: data pointer, device, shape, and strides.
-    pub(crate) fn tensor(&self) -> &DLTensor {
+    pub fn tensor(&self) -> &DLTensor {
         self.0
             .as_ref()
             .expect("the tensor is taken only while dropping")
@@ -191,7 +191,7 @@ impl PyManagedTensor {
     ///
     /// This returns an `Err` for a tensor that is not on the host, or whose strides are not
     /// compact.
-    pub(crate) fn as_bytes(&self) -> ZarristaResult<&[u8]> {
+    pub fn as_bytes(&self) -> ZarristaResult<&[u8]> {
         let tensor = self.tensor();
 
         // Every call below needs the same thing: that the producer's `shape`,
@@ -243,7 +243,7 @@ impl PyManagedTensor {
     }
 
     /// The tensor's shape, in elements along each dimension.
-    pub(crate) fn shape(&self) -> ZarristaResult<Vec<u64>> {
+    pub fn shape(&self) -> ZarristaResult<Vec<u64>> {
         // SAFETY: `Self` owns the tensor, so the producer's shape, strides, and
         // data pointer stay valid and readable for this borrow.
         let shape = unsafe { self.tensor().shape().map_err(dlpack_import_error)? };

--- a/src/data/dlpack.rs
+++ b/src/data/dlpack.rs
@@ -166,3 +166,34 @@ impl DLPackDataTypeExt for DLDataType {
         Ok(DLDataType::scalar(code, bits))
     }
 }
+
+/// A DLPack tensor from a Python producer
+///
+/// We customize this to run `Drop` with the GIL held, since the producer may need to change Python
+/// state.
+pub struct PyManagedTensor(Option<ManagedBox<DLManagedTensorVersioned>>);
+
+// SAFETY: the tensor's buffer is plain memory that stays valid until the
+// deleter runs, so reading it needs no GIL and is sound from any thread. The
+// deleter is the only operation that touches the interpreter, and `Drop` always
+// runs it under `Python::try_attach`.
+unsafe impl Send for PyManagedTensor {}
+impl Drop for PyManagedTensor {
+    fn drop(&mut self) {
+        // Try to drop the tensor with the GIL held.
+        let drop_successful = Python::try_attach(|_py| drop(self.0.take())).is_some();
+
+        // If the GIL could not be acquired, the interpreter is shutting down and the deleter
+        // cannot run safely.
+        //
+        // We leak the tensor instead of running the deleter. The process is ending, so the memory
+        // returns to the operating system regardless.
+        //
+        // Numpy appears to do the same. If the interpreter is shutting down, it does not run the
+        // deleter, and the memory leaks.
+        // <https://github.com/numpy/numpy/blob/4978efe1055ddda49a26524bca5ae6a2d01e6802/numpy/_core/src/multiarray/dlpack.c#L91-L115>
+        if !drop_successful {
+            std::mem::forget(self.0.take());
+        }
+    }
+}

--- a/src/data/dlpack.rs
+++ b/src/data/dlpack.rs
@@ -188,6 +188,55 @@ impl PyManagedTensor {
             .tensor()
     }
 
+    /// The tensor's bytes, borrowed for as long as this owns them.
+    ///
+    /// This returns an `Err` for a tensor that is not on the host, or whose strides are not
+    /// compact.
+    pub(crate) fn as_bytes(&self) -> ZarristaResult<&[u8]> {
+        let tensor = self.tensor();
+
+        // Every call below needs the same thing: that the producer's `shape`,
+        // `strides`, and `data` pointers describe what the DLPack ABI says they
+        // do. `Self` owns the tensor, so the deleter has not run and none of
+        // them dangle. dlpark reports a null or negative `ndim` as an error
+        // rather than reading through it, so only a producer that lies about
+        // its own metadata could break these.
+
+        // SAFETY: the shape and strides pointers are the producer's own.
+        let is_compact = unsafe { tensor.is_compact() }.map_err(dlpack_import_error)?;
+        if !is_compact {
+            // Load-bearing, not just a convenience: `num_bytes` below describes
+            // the logical tensor, which only matches the bytes at the data
+            // pointer when the strides are compact.
+            return Err(PyValueError::new_err(
+                "the data is not C-contiguous. Make it contiguous first, \
+                 for example with `numpy.ascontiguousarray`.",
+            )
+            .into());
+        }
+
+        // SAFETY: the shape pointer is the producer's own.
+        let len = unsafe { tensor.num_bytes() }.map_err(dlpack_import_error)?;
+        if len == 0 {
+            return Ok(&[]);
+        }
+
+        // SAFETY: the shape and data pointers are the producer's own.
+        //
+        // This rejects a tensor on another device, so a device pointer can never reach the slice
+        // below, and it rejects a null pointer for a tensor that is not empty.
+        let ptr = unsafe { tensor.cpu_data_ptr_bytes() }.map_err(dlpack_import_error)?;
+
+        // SAFETY: `ptr` is non-null, and `u8` needs no alignment.
+        //
+        // The tensor is compact, so `len` bytes from `ptr` are exactly its initialized elements,
+        // inside the producer's allocation.
+        //
+        // The DLPack contract gives a consumer read access until it runs the deleter, which `Self`
+        // owns and has not run. The lifetime is the same as `&self`, so the slice cannot outlive
+        // the tensor that backs it.
+        Ok(unsafe { std::slice::from_raw_parts(ptr, len) })
+    }
 
     /// Access the zarr data type
     pub fn data_type(&self) -> ZarristaResult<DataType> {

--- a/src/data/dlpack.rs
+++ b/src/data/dlpack.rs
@@ -179,6 +179,34 @@ pub struct PyManagedTensor(Option<ManagedBox<DLManagedTensorVersioned>>);
 // runs it under `Python::try_attach`.
 unsafe impl Send for PyManagedTensor {}
 
+impl PyManagedTensor {
+    /// The DLPack tensor description: data pointer, device, shape, and strides.
+    pub(crate) fn tensor(&self) -> &DLTensor {
+        self.0
+            .as_ref()
+            .expect("the tensor is taken only while dropping")
+            .tensor()
+    }
+
+
+    /// Access the zarr data type
+    pub fn data_type(&self) -> ZarristaResult<DataType> {
+        self.tensor().dtype.zarrs_data_type()
+    }
+
+    /// The tensor's shape, in elements along each dimension.
+    pub(crate) fn shape(&self) -> ZarristaResult<Vec<u64>> {
+        // SAFETY: `Self` owns the tensor, so the producer's shape, strides, and
+        // data pointer stay valid and readable for this borrow.
+        let shape = unsafe { self.tensor().shape().map_err(dlpack_import_error)? };
+        shape
+            .iter()
+            .map(|dim| u64::try_from(*dim))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| PyValueError::new_err("the data has a negative dimension").into())
+    }
+}
+
 impl FromPyObject<'_, '_> for PyManagedTensor {
     type Error = PyErr;
 

--- a/src/data/dlpack.rs
+++ b/src/data/dlpack.rs
@@ -1,13 +1,12 @@
 use std::ffi::c_void;
 
-use dlpark::ManagedBox;
 use dlpark::ffi::{
     DLDataType, DLDataTypeCode, DLDevice, DLDeviceType, DLManagedTensorVersioned,
     DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION, DLTensor,
 };
 use dlpark::metadata::CopiedSlice;
 use dlpark::python::device::dlpack_device;
-use dlpark::{Builder, legacy};
+use dlpark::{Builder, ManagedBox, legacy};
 use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;

--- a/src/data/dlpack.rs
+++ b/src/data/dlpack.rs
@@ -178,6 +178,40 @@ pub struct PyManagedTensor(Option<ManagedBox<DLManagedTensorVersioned>>);
 // deleter is the only operation that touches the interpreter, and `Drop` always
 // runs it under `Python::try_attach`.
 unsafe impl Send for PyManagedTensor {}
+
+impl FromPyObject<'_, '_> for PyManagedTensor {
+    type Error = PyErr;
+
+    /// Import a DLPack tensor, asking the provider to copy it to CPU memory if necessary.
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
+        let py = obj.py();
+        let kwargs = PyDict::new(py);
+        kwargs.set_item(
+            intern!(py, "max_version"),
+            (DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION),
+        )?;
+        kwargs.set_item(intern!(py, "dl_device"), (DLDeviceType::CPU.0, 0))?;
+
+        let capsule = obj
+            .call_method(intern!(py, "__dlpack__"), (), Some(&kwargs))
+            .map_err(|err| {
+                let device = dlpack_device(obj).map_or_else(
+                    |_| "an unknown device".to_string(),
+                    |device| format!("device {:?}", device.device_type),
+                );
+                PyValueError::new_err(format!(
+                    "The data is on {device}, and the producer could not move it to the host: {err}."
+                ))
+            })?;
+
+        // dlpark reads a capsule directly, so this does not call `__dlpack__`
+        // a second time.
+        Ok(Self(Some(
+            capsule.extract::<ManagedBox<DLManagedTensorVersioned>>()?,
+        )))
+    }
+}
+
 impl Drop for PyManagedTensor {
     fn drop(&mut self) {
         // Try to drop the tensor with the GIL held.
@@ -196,4 +230,9 @@ impl Drop for PyManagedTensor {
             std::mem::forget(self.0.take());
         }
     }
+}
+
+/// Add DLPack error prefix text
+fn dlpack_import_error(err: impl std::fmt::Display) -> PyErr {
+    PyValueError::new_err(format!("Error in DLPack import: {err}"))
 }

--- a/src/data/input.rs
+++ b/src/data/input.rs
@@ -1,24 +1,23 @@
+//! Holds [PyDataInput] and manages conversion from Python in-memory array-like objects into
+//! Rust-accessible data
+
 use std::borrow::Cow;
 
-use bytes::Bytes;
 use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3_bytes::PyBytes;
 use zarrs::array::{ArrayBytes, DataType};
 
 use crate::array_bytes::PyArrayBytes;
+use crate::data::dlpack::PyManagedTensor;
 use crate::error::ZarristaResult;
 
 pub enum PyDataInput {
     /// Raw bytes. No type information, so length is all we can check.
     Bytes(PyBytes),
-    /// A typed buffer from `__dlpack__` or the buffer protocol,
-    /// normalised to C-contiguous native-order bytes at extraction.
-    Typed {
-        bytes: Bytes,
-        input_dtype: DataType,
-        input_shape: Vec<u64>,
-    },
+    /// A DLPack tensor
+    DLPack(PyManagedTensor),
     /// The explicit `ArrayBytes` class: variable-length and masked data.
     ArrayBytes(PyArrayBytes),
 }
@@ -26,32 +25,32 @@ pub enum PyDataInput {
 impl PyDataInput {
     pub fn as_array_bytes(
         &self,
-        data_type: &DataType,
-        shape: &[u64],
+        array_data_type: &DataType,
+        array_shape: &[u64],
     ) -> ZarristaResult<ArrayBytes<'_>> {
         match self {
             PyDataInput::Bytes(bytes) => Ok(ArrayBytes::Fixed(Cow::Borrowed(bytes.as_ref()))),
-            PyDataInput::Typed {
-                bytes,
-                input_dtype,
-                input_shape,
-            } => {
-                if input_dtype != data_type {
+            PyDataInput::DLPack(tensor) => {
+                let data_data_type = &tensor.data_type()?;
+                if data_data_type != array_data_type {
                     // A cast can lose data, so the user has to ask for it.
-                    let input_name = data_type_display(input_dtype);
-                    let target_name = data_type_display(data_type);
+                    let input_name = data_type_display(data_data_type);
+                    let target_name = data_type_display(array_data_type);
                     return Err(PyTypeError::new_err(format!(
                         "the data has type {input_name}, but the array has type {target_name}."
                     ))
                     .into());
                 }
-                if input_shape.as_slice() != shape {
+
+                let data_shape = tensor.shape()?;
+                if data_shape.as_slice() != array_shape {
                     return Err(PyValueError::new_err(format!(
-                        "the data has shape {input_shape:?}, but the destination has shape {shape:?}."
+                        "the data has shape {data_shape:?}, but the destination has shape {array_shape:?}."
                     ))
                     .into());
                 }
-                Ok(ArrayBytes::Fixed(Cow::Borrowed(bytes)))
+
+                Ok(ArrayBytes::Fixed(Cow::Borrowed(tensor.as_bytes()?)))
             }
             PyDataInput::ArrayBytes(array_bytes) => Ok(array_bytes.as_array_bytes()?),
         }
@@ -69,15 +68,13 @@ impl FromPyObject<'_, '_> for PyDataInput {
 
         // 2. DLPack extraction
         if obj.hasattr(intern!(obj.py(), "__dlpack__"))? {
-            return import_dlpack(obj);
+            return Ok(Self::DLPack(obj.extract()?));
         }
 
         // Anything else that exposes bytes. There is no type information here,
         // so the caller has opted out of the data type and shape checks.
         Ok(Self::Bytes(obj.extract::<PyBytes>()?))
     }
-}
-
 }
 
 /// The Zarr v3 name of `data_type`, for use in a user-facing message.

--- a/src/data/input.rs
+++ b/src/data/input.rs
@@ -79,7 +79,7 @@ impl FromPyObject<'_, '_> for PyDataInput {
 
         let type_name = obj.get_type().name()?;
         Err(PyTypeError::new_err(format!(
-            "Expected one of `PyArrayBytes`, a DLPack tensor, or a buffer, but got {type_name}."
+            "Expected one of ArrayBytes, a DLPack tensor, or a buffer, but got {type_name}."
         )))
     }
 }

--- a/src/data/input.rs
+++ b/src/data/input.rs
@@ -73,7 +73,14 @@ impl FromPyObject<'_, '_> for PyDataInput {
 
         // Anything else that exposes bytes. There is no type information here,
         // so the caller has opted out of the data type and shape checks.
-        Ok(Self::Bytes(obj.extract::<PyBytes>()?))
+        if let Ok(buf) = obj.extract::<PyBytes>() {
+            return Ok(Self::Bytes(buf));
+        }
+
+        let type_name = obj.get_type().name()?;
+        Err(PyTypeError::new_err(format!(
+            "Expected one of `PyArrayBytes`, a DLPack tensor, or a buffer, but got {type_name}."
+        )))
     }
 }
 

--- a/src/data/input.rs
+++ b/src/data/input.rs
@@ -73,13 +73,16 @@ impl FromPyObject<'_, '_> for PyDataInput {
 
         // Anything else that exposes bytes. There is no type information here,
         // so the caller has opted out of the data type and shape checks.
-        if let Ok(buf) = obj.extract::<PyBytes>() {
-            return Ok(Self::Bytes(buf));
-        }
+        let buffer_import_error = match obj.extract::<PyBytes>() {
+            Ok(buf) => return Ok(Self::Bytes(buf)),
+            Err(err) => err,
+        };
 
         let type_name = obj.get_type().name()?;
         Err(PyTypeError::new_err(format!(
-            "Expected one of ArrayBytes, a DLPack tensor, or a buffer, but got {type_name}."
+            "expected an ArrayBytes, an object that supports DLPack such as a \
+             numpy array, or an object that exposes bytes, but got `{type_name}`. \
+             Extracting a buffer failed with: {buffer_import_error}"
         )))
     }
 }

--- a/src/data/input.rs
+++ b/src/data/input.rs
@@ -62,8 +62,22 @@ impl FromPyObject<'_, '_> for PyDataInput {
     type Error = PyErr;
 
     fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
-        todo!()
+        // 1. Check for literal PyArrayBytes pyclass
+        if let Ok(array_bytes) = obj.cast::<PyArrayBytes>() {
+            return Ok(Self::ArrayBytes(array_bytes.get().clone()));
+        }
+
+        // 2. DLPack extraction
+        if obj.hasattr(intern!(obj.py(), "__dlpack__"))? {
+            return import_dlpack(obj);
+        }
+
+        // Anything else that exposes bytes. There is no type information here,
+        // so the caller has opted out of the data type and shape checks.
+        Ok(Self::Bytes(obj.extract::<PyBytes>()?))
     }
+}
+
 }
 
 /// The Zarr v3 name of `data_type`, for use in a user-facing message.

--- a/src/data/input.rs
+++ b/src/data/input.rs
@@ -1,0 +1,78 @@
+use std::borrow::Cow;
+
+use bytes::Bytes;
+use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3_bytes::PyBytes;
+use zarrs::array::{ArrayBytes, DataType};
+
+use crate::array_bytes::PyArrayBytes;
+use crate::error::ZarristaResult;
+
+pub enum PyDataInput {
+    /// Raw bytes. No type information, so length is all we can check.
+    Bytes(PyBytes),
+    /// A typed buffer from `__dlpack__` or the buffer protocol,
+    /// normalised to C-contiguous native-order bytes at extraction.
+    Typed {
+        bytes: Bytes,
+        input_dtype: DataType,
+        input_shape: Vec<u64>,
+    },
+    /// The explicit `ArrayBytes` class: variable-length and masked data.
+    ArrayBytes(PyArrayBytes),
+}
+
+impl PyDataInput {
+    pub fn as_array_bytes(
+        &self,
+        data_type: &DataType,
+        shape: &[u64],
+    ) -> ZarristaResult<ArrayBytes<'_>> {
+        match self {
+            PyDataInput::Bytes(bytes) => Ok(ArrayBytes::Fixed(Cow::Borrowed(bytes.as_ref()))),
+            PyDataInput::Typed {
+                bytes,
+                input_dtype,
+                input_shape,
+            } => {
+                if input_dtype != data_type {
+                    // A cast can lose data, so the user has to ask for it.
+                    let input_name = data_type_display(input_dtype);
+                    let target_name = data_type_display(data_type);
+                    return Err(PyTypeError::new_err(format!(
+                        "the data has type {input_name}, but the array has type {target_name}."
+                    ))
+                    .into());
+                }
+                if input_shape.as_slice() != shape {
+                    return Err(PyValueError::new_err(format!(
+                        "the data has shape {input_shape:?}, but the destination has shape {shape:?}."
+                    ))
+                    .into());
+                }
+                Ok(ArrayBytes::Fixed(Cow::Borrowed(bytes)))
+            }
+            PyDataInput::ArrayBytes(array_bytes) => Ok(array_bytes.as_array_bytes()?),
+        }
+    }
+}
+
+impl FromPyObject<'_, '_> for PyDataInput {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+/// The Zarr v3 name of `data_type`, for use in a user-facing message.
+///
+/// `DataType`'s `Display` renders as `int32 / <i4`, which is informative but is
+/// not something a user can paste into `astype`. Fall back to it only for a data
+/// type that has no Zarr v3 name.
+fn data_type_display(data_type: &DataType) -> Cow<'_, str> {
+    data_type
+        .name_v3()
+        .unwrap_or_else(|| Cow::Owned(data_type.to_string()))
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -21,6 +21,7 @@
 
 mod buffer_protocol;
 mod dlpack;
+mod input;
 mod tensor;
 mod variable;
 
@@ -28,6 +29,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use bytes::Bytes;
+pub use input::PyDataInput;
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 pub use tensor::{PyMaskedTensor, PyTensor};

--- a/tests/data/test_dlpack.py
+++ b/tests/data/test_dlpack.py
@@ -1,0 +1,314 @@
+"""DLPack exchange in both directions.
+
+zarrista exports decoded data as a DLPack tensor (`Tensor.__dlpack__`), and
+imports array-like data through DLPack when writing. The import path is what
+lets `arr[...] = ndarray` check the data type and shape, because DLPack carries
+both; raw bytes carry neither.
+"""
+
+import gc
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+from obstore.store import LocalStore
+
+from zarrista import (
+    Array,
+    ArrayBuilder,
+    ChunkGrid,
+    DataType,
+    FillValue,
+    Tensor,
+)
+from zarrista.store import MemoryStore
+
+# Every data type the DLPack mapping covers and numpy can express. `bfloat16`
+# is in the mapping but numpy has no such type, so it is not listed here.
+DTYPES = [
+    "bool",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "float16",
+    "float32",
+    "float64",
+]
+
+
+def _fill_value(dtype: str) -> FillValue:
+    return FillValue(np.zeros((), dtype=dtype).tobytes())
+
+
+def _array(dtype: str = "int32", *, shape: list[int] | None = None) -> Array:
+    shape = shape or [4, 4]
+    return ArrayBuilder(
+        ChunkGrid.regular(shape, [2, 2]),
+        DataType.from_string(dtype),
+        _fill_value(dtype),
+    ).create(MemoryStore(), "/a")
+
+
+def _data(dtype: str = "int32") -> NDArray:
+    values = np.arange(16).reshape(4, 4)
+    # `arange` refuses to build a bool array of this length.
+    return (values % 3 == 0) if dtype == "bool" else values.astype(dtype)
+
+
+def _all() -> tuple[slice, slice]:
+    return (slice(0, 4), slice(0, 4))
+
+
+# --- import: writing an array-like -----------------------------------------
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_write_ndarray_round_trips(dtype: str):
+    """Every data type in the DLPack mapping survives a write and a read."""
+    arr = _array(dtype)
+    data = _data(dtype)
+
+    arr.store_array_subset(_all(), data)
+
+    np.testing.assert_array_equal(np.asarray(arr[:, :]), data)
+
+
+def test_write_needs_no_tobytes():
+    """The point of the import path: a typed array goes in directly."""
+    arr = _array()
+    data = _data()
+
+    arr.store_array_subset(_all(), data)
+
+    np.testing.assert_array_equal(np.asarray(arr[:, :]), data)
+
+
+def test_write_a_sub_region():
+    arr = _array()
+    data = _data()
+    arr.store_array_subset(_all(), data)
+
+    replacement = np.full((2, 2), 99, dtype="int32")
+    arr.store_array_subset((slice(0, 2), slice(0, 2)), replacement)
+
+    expected = data.copy()
+    expected[:2, :2] = 99
+    np.testing.assert_array_equal(np.asarray(arr[:, :]), expected)
+
+
+def test_raw_bytes_skip_the_checks():
+    """Bytes carry no type information, so the caller opts out of both checks."""
+    arr = _array()
+    data = _data()
+
+    arr.store_array_subset(_all(), data.tobytes())
+
+    np.testing.assert_array_equal(np.asarray(arr[:, :]), data)
+
+
+# --- import: what gets rejected ---------------------------------------------
+
+
+def test_data_type_mismatch_raises():
+    """A cast can lose data, so the caller has to ask for it."""
+    arr = _array("int32")
+
+    with pytest.raises(TypeError, match=r"float64.*int32"):
+        arr.store_array_subset(_all(), _data("float64"))
+
+
+def test_shape_mismatch_raises():
+    """The element count matches here, so only the shape check catches it."""
+    arr = _array()
+
+    with pytest.raises(ValueError, match=r"shape \[4, 4\].*shape \[2, 2\]"):
+        arr.store_array_subset((slice(0, 2), slice(0, 2)), _data())
+
+
+@pytest.mark.parametrize(
+    ("label", "make"),
+    [
+        ("strided view", lambda d: d[:, ::2]),
+        ("fortran order", np.asfortranarray),
+        ("transposed", lambda d: d.T),
+    ],
+)
+def test_non_contiguous_raises(label: str, make):
+    """A non-compact tensor's byte length does not describe its elements."""
+    arr = _array()
+    data = make(_data())
+    selection = (slice(0, 4), slice(0, data.shape[1]))
+
+    with pytest.raises(ValueError, match="C-contiguous"):
+        arr.store_array_subset(selection, data)
+
+
+def test_ascontiguousarray_is_the_documented_fix():
+    arr = _array()
+    strided = _data()[:, ::2]
+
+    arr.store_array_subset(
+        (slice(0, 4), slice(0, 2)),
+        np.ascontiguousarray(strided),
+    )
+
+    np.testing.assert_array_equal(np.asarray(arr[0:4, 0:2]), strided)
+
+
+# --- import: the DLPack negotiation -----------------------------------------
+
+
+class _OffDevice:
+    """Claims to be on CUDA, and honours a host request like a real producer.
+
+    zarrs encodes on the host, so zarrista asks the producer to move the data
+    with `dl_device` rather than moving it itself.
+    """
+
+    def __init__(self, data: NDArray) -> None:
+        self.data = data
+        self.requested: dict | None = None
+
+    def __dlpack_device__(self) -> tuple[int, int]:
+        return (2, 0)  # kDLCUDA
+
+    def __dlpack__(self, **kwargs: object) -> object:
+        self.requested = kwargs
+        return self.data.__dlpack__(max_version=kwargs["max_version"])
+
+
+def test_off_device_data_is_requested_on_the_host():
+    arr = _array()
+    data = _data()
+    producer = _OffDevice(data)
+
+    arr.store_array_subset(_all(), producer)
+
+    assert producer.requested is not None
+    assert producer.requested["dl_device"] == (1, 0)  # kDLCPU
+    np.testing.assert_array_equal(np.asarray(arr[:, :]), data)
+
+
+class _OldProducer:
+    """Predates `dl_device`, as a producer from before the 2023.12 array API."""
+
+    def __dlpack_device__(self) -> tuple[int, int]:
+        return (2, 0)
+
+    def __dlpack__(self) -> object:
+        raise TypeError("__dlpack__() got an unexpected keyword argument 'dl_device'")
+
+
+def test_producer_without_dl_device_reports_the_device():
+    arr = _array()
+
+    with pytest.raises(ValueError, match="could not move it to the host"):
+        arr.store_array_subset(_all(), _OldProducer())
+
+
+# --- import: ownership ------------------------------------------------------
+
+
+def test_the_source_array_can_be_dropped_after_the_call():
+    """The tensor keeps the producer's buffer alive, so the write owns nothing
+    borrowed from Python's stack."""
+    arr = _array()
+    expected = _data()
+
+    data = _data()
+    arr.store_array_subset(_all(), data)
+    del data
+    gc.collect()
+
+    np.testing.assert_array_equal(np.asarray(arr[:, :]), expected)
+
+
+async def test_async_write_outlives_the_source_array(tmp_path):
+    """The async write moves the tensor into a `'static` future, and its
+    deleter runs on whichever thread drops that future."""
+    arr = await ArrayBuilder(
+        ChunkGrid.regular([4, 4], [2, 2]),
+        DataType.from_string("int32"),
+        _fill_value("int32"),
+    ).create_async(LocalStore(str(tmp_path)), "/a")
+    expected = _data()
+
+    data = _data()
+    pending = arr.store_array_subset(_all(), data)
+    del data
+    gc.collect()
+    await pending
+
+    np.testing.assert_array_equal(np.asarray(await arr[:, :]), expected)
+
+
+async def test_many_concurrent_async_writes(tmp_path):
+    """Exercises dropping several tensors on the runtime's worker threads."""
+    import asyncio
+
+    arr = await ArrayBuilder(
+        ChunkGrid.regular([4, 4], [2, 2]),
+        DataType.from_string("int32"),
+        _fill_value("int32"),
+    ).create_async(LocalStore(str(tmp_path)), "/a")
+
+    await asyncio.gather(
+        *(
+            arr.store_array_subset(
+                (slice(r, r + 2), slice(c, c + 2)),
+                np.full((2, 2), r * 2 + c, dtype="int32"),
+            )
+            for r in (0, 2)
+            for c in (0, 2)
+        ),
+    )
+
+    result = np.asarray(await arr[:, :])
+    assert result[0, 0] == 0
+    assert result[2, 2] == 6
+
+
+# --- export -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_export_round_trips_through_numpy(dtype: str):
+    arr = _array(dtype)
+    data = _data(dtype)
+    arr.store_array_subset(_all(), data)
+
+    tensor = arr[:, :]
+    assert isinstance(tensor, Tensor)
+
+    np.testing.assert_array_equal(np.from_dlpack(tensor), data)
+
+
+def test_export_reports_a_cpu_device():
+    arr = _array()
+    arr.store_array_subset(_all(), _data())
+
+    assert arr[:, :].__dlpack_device__() == (1, 0)  # kDLCPU
+
+
+@pytest.mark.xfail(
+    reason="`Tensor.__dlpack__` ignores `max_version` and always exports a "
+    "legacy capsule, which the versioned importer cannot read. See "
+    "developmentseed/zarrista#108 and the DLPack ownership design.",
+    raises=AttributeError,
+    strict=True,
+)
+def test_export_then_import_round_trips():
+    """A `Tensor` read from one array can be written straight into another."""
+    source = _array()
+    data = _data()
+    source.store_array_subset(_all(), data)
+
+    destination = _array()
+    destination.store_array_subset(_all(), source[:, :])
+
+    np.testing.assert_array_equal(np.asarray(destination[:, :]), data)


### PR DESCRIPTION
### Change list

- Adds `Array.store_array_subset` and `AsyncArray.store_array_subset`, which take in a selection definition and array data, and write them to the backend store.
- Manages conversion of DLPack objects into Rust objects with accessible underlying data
    - For now, DLPack input must be C-ordered and contiguous. In the future we'll support copying the input data for non-contiguous input.

### Todo:

- We need to support importing both the new-style _versioned_ DLPack interface and the legacy DLPack interface
- Non-contiguous input should copy, not error
- `store_chunk` and `store_chunk_subset` should be updated to take `DataInput`
- Return to design chunk encoding API design to split CPU/IO when uploading chunks

Partially solves https://github.com/developmentseed/zarrista/issues/106, partially solves https://github.com/developmentseed/zarrista/issues/47