### PR TITLE
perf: Release GIL for synchronous methods

### DIFF
--- a/src/array/builder.rs
+++ b/src/array/builder.rs
@@ -80,10 +80,12 @@ impl PyArrayBuilder {
         })
     }
 
-    fn create(&self, store: PySyncStorage, path: &str) -> ZarristaResult<PyArray> {
-        let array = self.0.build_arc(store.inner(), path)?;
-        array.store_metadata()?;
-        Ok(PyArray::new(array, store))
+    fn create(&self, py: Python, store: PySyncStorage, path: &str) -> ZarristaResult<PyArray> {
+        crate::py::detach(py, || {
+            let array = self.0.build_arc(store.inner(), path)?;
+            array.store_metadata()?;
+            Ok(PyArray::new(array, store))
+        })
     }
 
     #[cfg(feature = "async")]

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -59,8 +59,8 @@ shared_array_methods!(PyArray);
 #[pymethods]
 impl PyArray {
     /// Read a region with numpy-style basic indexing, e.g. `arr[0:10, :, 5]`.
-    fn __getitem__(&self, selection: PySelection) -> ZarristaResult<DecodedArray> {
-        self.retrieve_array_subset(selection)
+    fn __getitem__(&self, py: Python, selection: PySelection) -> ZarristaResult<DecodedArray> {
+        self.retrieve_array_subset(py, selection)
     }
 
     fn __repr__(&self) -> String {
@@ -102,24 +102,31 @@ impl PyArray {
     #[pyo3(signature = (chunk_indices, **codec_options))]
     fn compact_chunk(
         &self,
+        py: Python,
         chunk_indices: PyChunkIndices,
         codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<bool> {
-        let codec_options = codec_options
-            .map(|opts| opts.into_inner())
-            .unwrap_or_default();
-        Ok(self.inner.compact_chunk(&chunk_indices, &codec_options)?)
+        py.detach(move || {
+            let codec_options = codec_options
+                .map(|opts| opts.into_inner())
+                .unwrap_or_default();
+            Ok(self.inner.compact_chunk(&chunk_indices, &codec_options)?)
+        })
     }
 
-    fn erase_chunk(&self, chunk_indices: PyChunkIndices) -> ZarristaResult<()> {
-        self.inner.erase_chunk(&chunk_indices)?;
-        Ok(())
+    fn erase_chunk(&self, py: Python, chunk_indices: PyChunkIndices) -> ZarristaResult<()> {
+        py.detach(|| {
+            self.inner.erase_chunk(&chunk_indices)?;
+            Ok(())
+        })
     }
 
-    fn erase_chunks(&self, chunks: PySelection) -> ZarristaResult<()> {
-        let chunks = self.chunk_grid_subset(&chunks)?;
-        self.inner.erase_chunks(&chunks)?;
-        Ok(())
+    fn erase_chunks(&self, py: Python, chunks: PySelection) -> ZarristaResult<()> {
+        py.detach(move || {
+            let chunks = self.chunk_grid_subset(&chunks)?;
+            self.inner.erase_chunks(&chunks)?;
+            Ok(())
+        })
     }
 
     fn erase_metadata(&self) -> ZarristaResult<()> {
@@ -140,91 +147,110 @@ impl PyArray {
     ///
     /// Returns one of the decoded result classes (`Tensor`, `VariableArray`,
     /// `MaskedTensor`, `MaskedVariableArray`) depending on the dtype layout.
-    fn retrieve_array_subset(&self, selection: PySelection) -> ZarristaResult<DecodedArray> {
-        let array_subset = self.array_subset(&selection)?;
-        Ok(self.inner.retrieve_array_subset(&array_subset)?)
+    fn retrieve_array_subset(
+        &self,
+        py: Python,
+        selection: PySelection,
+    ) -> ZarristaResult<DecodedArray> {
+        py.detach(move || {
+            let array_subset = self.array_subset(&selection)?;
+            Ok(self.inner.retrieve_array_subset(&array_subset)?)
+        })
     }
 
     #[pyo3(signature = (chunk_indices, **codec_options))]
     fn retrieve_chunk(
         &self,
+        py: Python,
         chunk_indices: PyChunkIndices,
         codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<DecodedArray> {
-        let codec_options = codec_options
-            .map(|opts| opts.into_inner())
-            .unwrap_or_default();
-        Ok(self
-            .inner
-            .retrieve_chunk_opt(&chunk_indices, &codec_options)?)
+        py.detach(move || {
+            let codec_options = codec_options
+                .map(|opts| opts.into_inner())
+                .unwrap_or_default();
+            Ok(self
+                .inner
+                .retrieve_chunk_opt(&chunk_indices, &codec_options)?)
+        })
     }
 
     fn retrieve_encoded_chunk(
         &self,
+        py: Python,
         chunk_indices: PyChunkIndices,
     ) -> ZarristaResult<Option<PyEncodedChunk>> {
-        let encoded = self.inner.retrieve_encoded_chunk(&chunk_indices)?;
-        let chunk_shape = self.inner.chunk_shape(&chunk_indices)?;
-        Ok(encoded.map(|buf| {
-            PyEncodedChunk::new(
-                buf.into(),
-                self.inner.codecs(),
-                self.inner.data_type().clone(),
-                self.inner.fill_value().clone(),
-                chunk_shape,
-            )
-        }))
+        py.detach(move || {
+            let encoded = self.inner.retrieve_encoded_chunk(&chunk_indices)?;
+            let chunk_shape = self.inner.chunk_shape(&chunk_indices)?;
+            Ok(encoded.map(|buf| {
+                PyEncodedChunk::new(
+                    buf.into(),
+                    self.inner.codecs(),
+                    self.inner.data_type().clone(),
+                    self.inner.fill_value().clone(),
+                    chunk_shape,
+                )
+            }))
+        })
     }
 
     fn retrieve_encoded_subchunk(
         &self,
+        py: Python,
         subchunk_indices: PyChunkIndices,
     ) -> ZarristaResult<Option<PyEncodedChunk>> {
-        // TODO: allow user to manage shard cache
-        let subchunk_cache = ArrayShardedReadableExtCache::new(&self.inner);
+        py.detach(move || {
+            // TODO: allow user to manage shard cache
+            let subchunk_cache = ArrayShardedReadableExtCache::new(&self.inner);
 
-        let Some(encoded) = self
-            .inner
-            .retrieve_encoded_subchunk(&subchunk_cache, &subchunk_indices)?
-        else {
-            return Ok(None);
-        };
+            let Some(encoded) = self
+                .inner
+                .retrieve_encoded_subchunk(&subchunk_cache, &subchunk_indices)?
+            else {
+                return Ok(None);
+            };
 
-        let subchunk_codec_chain =
-            self.inner.codecs().subchunk_chain()?.expect(
+            let subchunk_codec_chain = self.inner.codecs().subchunk_chain()?.expect(
                 "zarrs accepts only an exclusively sharded array, so the serializer shards",
             );
 
-        let subchunk_shape = self
-            .inner
-            .effective_subchunk_shape()
-            .expect("an exclusively sharded array has no outer array-to-array codecs");
+            let subchunk_shape = self
+                .inner
+                .effective_subchunk_shape()
+                .expect("an exclusively sharded array has no outer array-to-array codecs");
 
-        Ok(Some(PyEncodedChunk::new(
-            encoded.into(),
-            subchunk_codec_chain,
-            self.inner.data_type().clone(),
-            self.inner.fill_value().clone(),
-            subchunk_shape,
-        )))
+            Ok(Some(PyEncodedChunk::new(
+                encoded.into(),
+                subchunk_codec_chain,
+                self.inner.data_type().clone(),
+                self.inner.fill_value().clone(),
+                subchunk_shape,
+            )))
+        })
     }
 
     #[pyo3(signature = (subchunk_indices, **codec_options))]
     fn retrieve_subchunk(
         &self,
+        py: Python,
         subchunk_indices: PyChunkIndices,
         codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<DecodedArray> {
-        let codec_options = codec_options
-            .map(|opts| opts.into_inner())
-            .unwrap_or_default();
+        py.detach(move || {
+            let codec_options = codec_options
+                .map(|opts| opts.into_inner())
+                .unwrap_or_default();
 
-        // TODO: allow user to manage shard cache
-        let subchunk_cache = ArrayShardedReadableExtCache::new(&self.inner);
+            // TODO: allow user to manage shard cache
+            let subchunk_cache = ArrayShardedReadableExtCache::new(&self.inner);
 
-        Ok(self
-            .inner
-            .retrieve_subchunk_opt(&subchunk_cache, &subchunk_indices, &codec_options)?)
+            Ok(self.inner.retrieve_subchunk_opt(
+                &subchunk_cache,
+                &subchunk_indices,
+                &codec_options,
+            )?)
+        })
     }
 
     #[getter]
@@ -235,55 +261,66 @@ impl PyArray {
     #[pyo3(signature = (selection, data, **codec_options))]
     fn store_array_subset(
         &self,
+        py: Python,
         selection: PySelection,
         data: PyDataInput,
         codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<()> {
-        let codec_options = codec_options
-            .map(|opts| opts.into_inner())
-            .unwrap_or_default();
-        let array_subset = self.array_subset(&selection)?;
-        let subset_data = data.as_array_bytes(self.inner.data_type(), array_subset.shape())?;
-        self.inner
-            .store_array_subset_opt(&array_subset, subset_data, &codec_options)?;
-        Ok(())
+        py.detach(move || {
+            let codec_options = codec_options
+                .map(|opts| opts.into_inner())
+                .unwrap_or_default();
+            let array_subset = self.array_subset(&selection)?;
+            let subset_data = data.as_array_bytes(self.inner.data_type(), array_subset.shape())?;
+            self.inner
+                .store_array_subset_opt(&array_subset, subset_data, &codec_options)?;
+            Ok(())
+        })
     }
 
     #[pyo3(signature = (chunk_indices, decoded_chunk, **codec_options))]
     fn store_chunk(
         &self,
+        py: Python,
         chunk_indices: PyChunkIndices,
         decoded_chunk: &PyArrayBytes,
         codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<()> {
-        let codec_options = codec_options
-            .map(|opts| opts.into_inner())
-            .unwrap_or_default();
-        self.inner.store_chunk_opt(
-            &chunk_indices,
-            decoded_chunk.as_array_bytes()?,
-            &codec_options,
-        )?;
-        Ok(())
+        py.detach(move || {
+            let codec_options = codec_options
+                .map(|opts| opts.into_inner())
+                .unwrap_or_default();
+            self.inner.store_chunk_opt(
+                &chunk_indices,
+                decoded_chunk.as_array_bytes()?,
+                &codec_options,
+            )?;
+            Ok(())
+        })
     }
 
     fn store_encoded_chunk(
         &self,
+        py: Python,
         chunk_indices: PyChunkIndices,
         encoded_chunk: PyBytes,
     ) -> ZarristaResult<()> {
-        // Safety:
-        // The responsibility is on the caller to ensure the chunk is encoded correctly
-        unsafe {
-            self.inner
-                .store_encoded_chunk(&chunk_indices, encoded_chunk.into_inner())?;
-        }
-        Ok(())
+        py.detach(move || {
+            // Safety:
+            // The responsibility is on the caller to ensure the chunk is encoded correctly
+            unsafe {
+                self.inner
+                    .store_encoded_chunk(&chunk_indices, encoded_chunk.into_inner())?;
+            }
+            Ok(())
+        })
     }
 
     /// Write the array metadata to the store.
-    fn store_metadata(&self) -> ZarristaResult<()> {
-        self.inner.store_metadata()?;
-        Ok(())
+    fn store_metadata(&self, py: Python) -> ZarristaResult<()> {
+        py.detach(|| {
+            self.inner.store_metadata()?;
+            Ok(())
+        })
     }
 }

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -94,8 +94,8 @@ impl PyArray {
         signature = (store, path = PyNodePath::root()),
         text_signature = "(store, path='/')"
     )]
-    fn open(store: PySyncStorage, path: PyNodePath) -> ZarristaResult<Self> {
-        let inner = Array::open(store.inner(), path.as_str())?;
+    fn open(py: Python, store: PySyncStorage, path: PyNodePath) -> ZarristaResult<Self> {
+        let inner = crate::py::detach(py, || Array::open(store.inner(), path.as_str()))?;
         Ok(Self::new(Arc::new(inner), store))
     }
 
@@ -106,7 +106,7 @@ impl PyArray {
         chunk_indices: PyChunkIndices,
         codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<bool> {
-        py.detach(move || {
+        crate::py::detach(py, move || {
             let codec_options = codec_options
                 .map(|opts| opts.into_inner())
                 .unwrap_or_default();
@@ -115,23 +115,25 @@ impl PyArray {
     }
 
     fn erase_chunk(&self, py: Python, chunk_indices: PyChunkIndices) -> ZarristaResult<()> {
-        py.detach(|| {
+        crate::py::detach(py, || {
             self.inner.erase_chunk(&chunk_indices)?;
             Ok(())
         })
     }
 
     fn erase_chunks(&self, py: Python, chunks: PySelection) -> ZarristaResult<()> {
-        py.detach(move || {
+        crate::py::detach(py, move || {
             let chunks = self.chunk_grid_subset(&chunks)?;
             self.inner.erase_chunks(&chunks)?;
             Ok(())
         })
     }
 
-    fn erase_metadata(&self) -> ZarristaResult<()> {
-        self.inner.erase_metadata()?;
-        Ok(())
+    fn erase_metadata(&self, py: Python) -> ZarristaResult<()> {
+        crate::py::detach(py, || {
+            self.inner.erase_metadata()?;
+            Ok(())
+        })
     }
 
     fn read_only(&self) -> Self {
@@ -152,7 +154,7 @@ impl PyArray {
         py: Python,
         selection: PySelection,
     ) -> ZarristaResult<DecodedArray> {
-        py.detach(move || {
+        crate::py::detach(py, move || {
             let array_subset = self.array_subset(&selection)?;
             Ok(self.inner.retrieve_array_subset(&array_subset)?)
         })
@@ -165,7 +167,7 @@ impl PyArray {
         chunk_indices: PyChunkIndices,
         codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<DecodedArray> {
-        py.detach(move || {
+        crate::py::detach(py, move || {
             let codec_options = codec_options
                 .map(|opts| opts.into_inner())
                 .unwrap_or_default();
@@ -180,7 +182,7 @@ impl PyArray {
         py: Python,
         chunk_indices: PyChunkIndices,
     ) -> ZarristaResult<Option<PyEncodedChunk>> {
-        py.detach(move || {
+        crate::py::detach(py, move || {
             let encoded = self.inner.retrieve_encoded_chunk(&chunk_indices)?;
             let chunk_shape = self.inner.chunk_shape(&chunk_indices)?;
             Ok(encoded.map(|buf| {
@@ -200,7 +202,7 @@ impl PyArray {
         py: Python,
         subchunk_indices: PyChunkIndices,
     ) -> ZarristaResult<Option<PyEncodedChunk>> {
-        py.detach(move || {
+        crate::py::detach(py, move || {
             // TODO: allow user to manage shard cache
             let subchunk_cache = ArrayShardedReadableExtCache::new(&self.inner);
 
@@ -237,7 +239,7 @@ impl PyArray {
         subchunk_indices: PyChunkIndices,
         codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<DecodedArray> {
-        py.detach(move || {
+        crate::py::detach(py, move || {
             let codec_options = codec_options
                 .map(|opts| opts.into_inner())
                 .unwrap_or_default();
@@ -266,7 +268,7 @@ impl PyArray {
         data: PyDataInput,
         codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<()> {
-        py.detach(move || {
+        crate::py::detach(py, move || {
             let codec_options = codec_options
                 .map(|opts| opts.into_inner())
                 .unwrap_or_default();
@@ -286,7 +288,7 @@ impl PyArray {
         decoded_chunk: &PyArrayBytes,
         codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<()> {
-        py.detach(move || {
+        crate::py::detach(py, move || {
             let codec_options = codec_options
                 .map(|opts| opts.into_inner())
                 .unwrap_or_default();
@@ -305,7 +307,7 @@ impl PyArray {
         chunk_indices: PyChunkIndices,
         encoded_chunk: PyBytes,
     ) -> ZarristaResult<()> {
-        py.detach(move || {
+        crate::py::detach(py, move || {
             // Safety:
             // The responsibility is on the caller to ensure the chunk is encoded correctly
             unsafe {
@@ -318,7 +320,7 @@ impl PyArray {
 
     /// Write the array metadata to the store.
     fn store_metadata(&self, py: Python) -> ZarristaResult<()> {
-        py.detach(|| {
+        crate::py::detach(py, || {
             self.inner.store_metadata()?;
             Ok(())
         })

--- a/src/codec/array_to_array.rs
+++ b/src/codec/array_to_array.rs
@@ -90,36 +90,42 @@ impl PyArrayToArrayCodec {
 
     fn encode(
         &self,
+        py: Python,
         bytes: &PyArrayBytes,
         shape: Vec<NonZeroU64>,
         data_type: &PyDataType,
         fill_value: &PyFillValue,
     ) -> ZarristaResult<PyArrayBytes> {
-        let encoded = self.0.encode(
-            bytes.as_array_bytes()?,
-            &shape,
-            data_type.inner(),
-            fill_value.inner(),
-            &CodecOptions::default(),
-        )?;
-        Ok(PyArrayBytes::from_zarrs(encoded))
+        py.detach(|| {
+            let encoded = self.0.encode(
+                bytes.as_array_bytes()?,
+                &shape,
+                data_type.inner(),
+                fill_value.inner(),
+                &CodecOptions::default(),
+            )?;
+            Ok(PyArrayBytes::from_zarrs(encoded))
+        })
     }
 
     fn decode(
         &self,
+        py: Python,
         bytes: &PyArrayBytes,
         shape: Vec<NonZeroU64>,
         data_type: &PyDataType,
         fill_value: &PyFillValue,
     ) -> ZarristaResult<PyArrayBytes> {
-        let decoded = self.0.decode(
-            bytes.as_array_bytes()?,
-            &shape,
-            data_type.inner(),
-            fill_value.inner(),
-            &CodecOptions::default(),
-        )?;
-        Ok(PyArrayBytes::from_zarrs(decoded))
+        py.detach(|| {
+            let decoded = self.0.decode(
+                bytes.as_array_bytes()?,
+                &shape,
+                data_type.inner(),
+                fill_value.inner(),
+                &CodecOptions::default(),
+            )?;
+            Ok(PyArrayBytes::from_zarrs(decoded))
+        })
     }
 
     fn encoded_shape(&self, decoded_shape: Vec<NonZeroU64>) -> ZarristaResult<Vec<NonZeroU64>> {

--- a/src/codec/array_to_array.rs
+++ b/src/codec/array_to_array.rs
@@ -96,7 +96,7 @@ impl PyArrayToArrayCodec {
         data_type: &PyDataType,
         fill_value: &PyFillValue,
     ) -> ZarristaResult<PyArrayBytes> {
-        py.detach(|| {
+        crate::py::detach(py, || {
             let encoded = self.0.encode(
                 bytes.as_array_bytes()?,
                 &shape,
@@ -116,7 +116,7 @@ impl PyArrayToArrayCodec {
         data_type: &PyDataType,
         fill_value: &PyFillValue,
     ) -> ZarristaResult<PyArrayBytes> {
-        py.detach(|| {
+        crate::py::detach(py, || {
             let decoded = self.0.decode(
                 bytes.as_array_bytes()?,
                 &shape,

--- a/src/codec/bytes_to_bytes/mod.rs
+++ b/src/codec/bytes_to_bytes/mod.rs
@@ -64,12 +64,14 @@ impl PyBytesToBytesCodec {
             .map(|config| config.into())
     }
 
-    fn encode(&self, decoded_value: PyBytes) -> ZarristaResult<PyBytes> {
-        let encoded = self.0.encode(
-            Cow::Borrowed(decoded_value.as_ref()),
-            &CodecOptions::default(),
-        )?;
-        Ok(PyBytes::new(encoded.into_owned().into()))
+    fn encode(&self, py: Python, decoded_value: PyBytes) -> ZarristaResult<PyBytes> {
+        py.detach(|| {
+            let encoded = self.0.encode(
+                Cow::Borrowed(decoded_value.as_ref()),
+                &CodecOptions::default(),
+            )?;
+            Ok(PyBytes::new(encoded.into_owned().into()))
+        })
     }
 
     /// The codec's Zarr v3 name if it has one.

--- a/src/codec/bytes_to_bytes/mod.rs
+++ b/src/codec/bytes_to_bytes/mod.rs
@@ -65,7 +65,7 @@ impl PyBytesToBytesCodec {
     }
 
     fn encode(&self, py: Python, decoded_value: PyBytes) -> ZarristaResult<PyBytes> {
-        py.detach(|| {
+        crate::py::detach(py, || {
             let encoded = self.0.encode(
                 Cow::Borrowed(decoded_value.as_ref()),
                 &CodecOptions::default(),

--- a/src/group/sync.rs
+++ b/src/group/sync.rs
@@ -50,114 +50,134 @@ impl PyGroup {
         signature = (store, path = PyNodePath::root()),
         text_signature = "(store, path='/')"
     )]
-    fn open(store: PySyncStorage, path: PyNodePath) -> ZarristaResult<Self> {
-        let inner = Group::open(store.inner(), path.as_str())?;
+    fn open(py: Python, store: PySyncStorage, path: PyNodePath) -> ZarristaResult<Self> {
+        let inner = crate::py::detach(py, || Group::open(store.inner(), path.as_str()))?;
         Ok(Self::new(Arc::new(inner), store))
     }
 
     /// Names of the direct child arrays.
-    fn array_keys(&self) -> ZarristaResult<Vec<String>> {
-        let paths = self.inner.child_array_paths()?;
-        Ok(paths.iter().map(|p| last_segment(p.as_str())).collect())
+    fn array_keys(&self, py: Python) -> ZarristaResult<Vec<String>> {
+        crate::py::detach(py, || {
+            let paths = self.inner.child_array_paths()?;
+            Ok(paths.iter().map(|p| last_segment(p.as_str())).collect())
+        })
     }
 
     /// Names of the direct child groups.
-    fn group_keys(&self) -> ZarristaResult<Vec<String>> {
-        let paths = self.inner.child_group_paths()?;
-        Ok(paths.iter().map(|p| last_segment(p.as_str())).collect())
+    fn group_keys(&self, py: Python) -> ZarristaResult<Vec<String>> {
+        crate::py::detach(py, || {
+            let paths = self.inner.child_group_paths()?;
+            Ok(paths.iter().map(|p| last_segment(p.as_str())).collect())
+        })
     }
 
     /// Open a direct child array or group by name.
-    fn __getitem__(&self, name: PyBackedStr) -> ZarristaResult<PyNode> {
-        self.child(name)
+    fn __getitem__(&self, py: Python, name: PyBackedStr) -> ZarristaResult<PyNode> {
+        self.child(py, name)
     }
 
-    fn child(&self, name: PyBackedStr) -> ZarristaResult<PyNode> {
-        let children = self.inner.children(false)?;
-        let selected_child = children
-            .into_iter()
-            .find(|child| child.name().as_str() == name.as_str())
-            .ok_or(PyKeyError::new_err(format!("child {name} not found")))?;
-        Ok(PyNode::new(selected_child, self.store.clone()))
+    fn child(&self, py: Python, name: PyBackedStr) -> ZarristaResult<PyNode> {
+        crate::py::detach(py, || {
+            let children = self.inner.children(false)?;
+            let selected_child = children
+                .into_iter()
+                .find(|child| child.name().as_str() == name)
+                .ok_or(PyKeyError::new_err(format!("child {name} not found")))?;
+            Ok(PyNode::new(selected_child, self.store.clone()))
+        })
     }
 
     /// Every node under the group, recursively, as `Array`/`Group` objects.
-    fn traverse(&self) -> ZarristaResult<Vec<PyArrayOrGroup>> {
-        self.inner
-            .traverse()?
-            .into_iter()
-            .map(|(path, metadata)| {
-                let storage = self.storage();
-                match metadata {
-                    NodeMetadata::Array(array_metadata) => {
-                        let array =
-                            Array::new_with_metadata(storage, path.as_str(), array_metadata)?;
-                        Ok(PyArray::new(Arc::new(array), self.store.clone()).into())
+    fn traverse(&self, py: Python) -> ZarristaResult<Vec<PyArrayOrGroup>> {
+        crate::py::detach(py, || {
+            self.inner
+                .traverse()?
+                .into_iter()
+                .map(|(path, metadata)| {
+                    let storage = self.storage();
+                    match metadata {
+                        NodeMetadata::Array(array_metadata) => {
+                            let array =
+                                Array::new_with_metadata(storage, path.as_str(), array_metadata)?;
+                            Ok(PyArray::new(Arc::new(array), self.store.clone()).into())
+                        }
+                        NodeMetadata::Group(group_metadata) => {
+                            let group =
+                                Group::new_with_metadata(storage, path.as_str(), group_metadata)?;
+                            Ok(PyGroup::new(Arc::new(group), self.store.clone()).into())
+                        }
                     }
-                    NodeMetadata::Group(group_metadata) => {
-                        let group =
-                            Group::new_with_metadata(storage, path.as_str(), group_metadata)?;
-                        Ok(PyGroup::new(Arc::new(group), self.store.clone()).into())
-                    }
-                }
-            })
-            .collect()
+                })
+                .collect()
+        })
     }
 
     /// The direct child arrays of the group.
-    fn child_arrays(&self) -> ZarristaResult<Vec<PyArray>> {
-        Ok(self
-            .inner
-            .child_arrays()?
-            .into_iter()
-            .map(|array| PyArray::new(Arc::new(array), self.store.clone()))
-            .collect())
+    fn child_arrays(&self, py: Python) -> ZarristaResult<Vec<PyArray>> {
+        crate::py::detach(py, || {
+            Ok(self
+                .inner
+                .child_arrays()?
+                .into_iter()
+                .map(|array| PyArray::new(Arc::new(array), self.store.clone()))
+                .collect())
+        })
     }
 
     /// The direct child groups of the group.
-    fn child_groups(&self) -> ZarristaResult<Vec<PyGroup>> {
-        Ok(self
-            .inner
-            .child_groups()?
-            .into_iter()
-            .map(|group| PyGroup::new(Arc::new(group), self.store.clone()))
-            .collect())
+    fn child_groups(&self, py: Python) -> ZarristaResult<Vec<PyGroup>> {
+        crate::py::detach(py, || {
+            Ok(self
+                .inner
+                .child_groups()?
+                .into_iter()
+                .map(|group| PyGroup::new(Arc::new(group), self.store.clone()))
+                .collect())
+        })
     }
 
     /// The full paths of the group's direct children.
-    fn child_paths(&self) -> ZarristaResult<Vec<PyNodePath>> {
-        Ok(self
-            .inner
-            .child_paths()?
-            .into_iter()
-            .map(|p| p.into())
-            .collect())
+    fn child_paths(&self, py: Python) -> ZarristaResult<Vec<PyNodePath>> {
+        crate::py::detach(py, || {
+            Ok(self
+                .inner
+                .child_paths()?
+                .into_iter()
+                .map(|p| p.into())
+                .collect())
+        })
     }
 
     /// The full paths of the group's direct child arrays.
-    fn child_array_paths(&self) -> ZarristaResult<Vec<PyNodePath>> {
-        Ok(self
-            .inner
-            .child_array_paths()?
-            .into_iter()
-            .map(|p| p.into())
-            .collect())
+    fn child_array_paths(&self, py: Python) -> ZarristaResult<Vec<PyNodePath>> {
+        crate::py::detach(py, || {
+            Ok(self
+                .inner
+                .child_array_paths()?
+                .into_iter()
+                .map(|p| p.into())
+                .collect())
+        })
     }
 
     /// The full paths of the group's direct child groups.
-    fn child_group_paths(&self) -> ZarristaResult<Vec<PyNodePath>> {
-        Ok(self
-            .inner
-            .child_group_paths()?
-            .into_iter()
-            .map(|p| p.into())
-            .collect())
+    fn child_group_paths(&self, py: Python) -> ZarristaResult<Vec<PyNodePath>> {
+        crate::py::detach(py, || {
+            Ok(self
+                .inner
+                .child_group_paths()?
+                .into_iter()
+                .map(|p| p.into())
+                .collect())
+        })
     }
 
     /// Erase the group metadata from the store. Succeeds if it does not exist.
-    fn erase_metadata(&self) -> ZarristaResult<()> {
-        self.inner.erase_metadata()?;
-        Ok(())
+    fn erase_metadata(&self, py: Python) -> ZarristaResult<()> {
+        crate::py::detach(py, || {
+            self.inner.erase_metadata()?;
+            Ok(())
+        })
     }
 
     #[getter]
@@ -166,9 +186,11 @@ impl PyGroup {
     }
 
     /// Write the group metadata to the store.
-    fn store_metadata(&self) -> ZarristaResult<()> {
-        self.inner.store_metadata()?;
-        Ok(())
+    fn store_metadata(&self, py: Python) -> ZarristaResult<()> {
+        crate::py::detach(py, || {
+            self.inner.store_metadata()?;
+            Ok(())
+        })
     }
 
     fn __repr__(&self) -> String {


### PR DESCRIPTION
Release GIL for all synchronous methods that perform IO or significant CPU work.

We can't release the GIL for async methods because we have to return a Python future.

Closes #124 