### PR TITLE
chore: Rename `DecodedArray` to `ArrayData`

### DIFF
--- a/docs/api/array-data.md
+++ b/docs/api/array-data.md
@@ -1,7 +1,7 @@
-# DecodedArray
+# Array data
 
-A read from an [`Array`][zarrista.Array] returns a `DecodedArray`. This applies to
-`retrieve_array_subset`, `retrieve_chunk`, and `[...]`. A `DecodedArray` is one of
+A read from an [`Array`][zarrista.Array] returns an `ArrayData`. This applies to
+`retrieve_array_subset`, `retrieve_chunk`, and `[...]`. An `ArrayData` is one of
 four concrete result types, and the decoded byte layout of the data type selects
 which one. Use `isinstance` to narrow to a concrete type before you call a method
 that belongs to one layout.
@@ -13,7 +13,7 @@ that belongs to one layout.
 - [`MaskedVariableArray`](#zarrista.MaskedVariableArray) — variable-length data with a
   validity mask.
 
-::: zarrista.DecodedArray
+::: zarrista.ArrayData
     options:
       show_bases: false
 

--- a/docs/api/array-data.md
+++ b/docs/api/array-data.md
@@ -1,5 +1,19 @@
 # Array data
 
+Three types carry array data, and they differ in where the data lives and in
+what it knows about itself.
+
+| Type | Where the data lives | Data type and shape |
+| --- | --- | --- |
+| [`Array`][zarrista.Array] | in the store, usually not in memory | yes, from the metadata |
+| [`ArrayBytes`][zarrista.ArrayBytes] | in memory | no |
+| `ArrayData` | in memory | yes |
+
+An `Array` addresses a whole Zarr array, which can be larger than memory. An
+`ArrayData` is a piece of one, decoded and in memory. An `ArrayBytes` is the
+same bytes without a data type or a shape, which is what a codec reads and
+writes.
+
 A read from an [`Array`][zarrista.Array] returns an `ArrayData`. This applies to
 `retrieve_array_subset`, `retrieve_chunk`, and `[...]`. An `ArrayData` is one of
 four concrete result types, and the decoded byte layout of the data type selects

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,10 +25,10 @@ nav:
       - api/builder.md
       - api/group.md
       - api/store.md
+      - api/array-data.md
       - api/chunk-grid.md
       - api/codec.md
       - api/concurrency.md
-      - api/decoded_array.md
       - api/dtype.md
       - api/encoded-chunk.md
       - api/exceptions.md

--- a/python/zarrista/__init__.py
+++ b/python/zarrista/__init__.py
@@ -24,12 +24,17 @@ from ._zarrista import (
 )
 
 ArrayData: TypeAlias = Tensor | VariableArray | MaskedTensor | MaskedVariableArray
-"""In-memory array data: one of the four layouts a read can return.
+"""In-memory array data, with its data type and shape.
 
-The layout depends on the byte layout of the data type. A data type is either
-fixed-width or variable-length, and it either carries a validity mask or does
-not. Use `isinstance` to narrow to a concrete type before you use a method that
-belongs to one layout.
+An [`Array`][zarrista.Array]/[`AsyncArray`][zarrista.AsyncArray] is a Zarr array that
+keeps its data in its `store`. It often references larger-than-memory data.
+
+An `ArrayData` is a typed piece of that data in memory.
+
+A read returns one of four layouts. The layout depends on the byte layout of
+the data type. A data type is either fixed-width or variable-length, and it
+either carries a validity mask or does not. Use `isinstance` to narrow to a
+concrete type before you use a method that belongs to one layout.
 """
 
 

--- a/python/zarrista/__init__.py
+++ b/python/zarrista/__init__.py
@@ -23,8 +23,8 @@ from ._zarrista import (
     __version__,
 )
 
-DecodedArray: TypeAlias = Tensor | VariableArray | MaskedTensor | MaskedVariableArray
-"""The result of a read: one of the four decoded array layouts.
+ArrayData: TypeAlias = Tensor | VariableArray | MaskedTensor | MaskedVariableArray
+"""In-memory array data: one of the four layouts a read can return.
 
 The layout depends on the byte layout of the data type. A data type is either
 fixed-width or variable-length, and it either carries a validity mask or does
@@ -37,12 +37,12 @@ __all__ = [
     "Array",
     "ArrayBuilder",
     "ArrayBytes",
+    "ArrayData",
     "AsyncArray",
     "AsyncGroup",
     "ChunkGrid",
     "ChunkKeyEncoding",
     "DataType",
-    "DecodedArray",
     "EncodedChunk",
     "FillValue",
     "Group",

--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -7,9 +7,9 @@ from zarr_metadata import JSONValue, ZarrV3ArrayMetadataJSON
 from zarrista.codec import CodecChain, CodecOptions
 
 from ._array_bytes import ArrayBytes
+from ._array_data import ArrayData
 from ._chunk_key_encoding import ChunkKeyEncoding
 from ._chunks import ChunkGrid
-from ._decoded_array import DecodedArray
 from ._dtype import DataType
 from ._encoded_chunk import EncodedChunk
 from ._fill_value import FillValue
@@ -188,7 +188,7 @@ class Array:
         self,
         selection: Selection,
         **codec_options: Unpack[CodecOptions],
-    ) -> DecodedArray:
+    ) -> ArrayData:
         """Read and decode an array region selected with numpy-style basic indexing.
 
         The result keeps the number of dimensions, which agrees with a zarrs
@@ -214,7 +214,7 @@ class Array:
         self,
         chunk_indices: list[int],
         **codec_options: Unpack[CodecOptions],
-    ) -> DecodedArray:
+    ) -> ArrayData:
         """Read and decode the chunk at the given chunk grid indices.
 
         Args:
@@ -246,7 +246,7 @@ class Array:
         self,
         subchunk_indices: list[int],
         **codec_options: Unpack[CodecOptions],
-    ) -> DecodedArray:
+    ) -> ArrayData:
         """Read and decode a single subchunk (inner chunk) of a sharded array.
 
         `subchunk_indices` index the subchunk grid (see `subchunk_grid_shape`).
@@ -560,7 +560,7 @@ class Array:
     @property
     def subset_all(self) -> tuple[slice, ...]:
         """The array subset that spans the entire array, as a tuple of slices."""
-    def __getitem__(self, selection: Selection) -> DecodedArray:
+    def __getitem__(self, selection: Selection) -> ArrayData:
         """Read a region with numpy-style basic indexing, e.g. `arr[0:10, :, 5]`.
 
         This is sugar for `retrieve_array_subset`.
@@ -714,7 +714,7 @@ class AsyncArray:
         self,
         selection: Selection,
         **codec_options: Unpack[CodecOptions],
-    ) -> DecodedArray:
+    ) -> ArrayData:
         """Read and decode an array region selected with numpy-style basic indexing.
 
         The result keeps the number of dimensions, which agrees with a zarrs
@@ -740,7 +740,7 @@ class AsyncArray:
         self,
         chunk_indices: list[int],
         **codec_options: Unpack[CodecOptions],
-    ) -> DecodedArray:
+    ) -> ArrayData:
         """Read and decode the chunk at the given chunk grid indices.
 
         Args:
@@ -775,7 +775,7 @@ class AsyncArray:
         self,
         subchunk_indices: list[int],
         **codec_options: Unpack[CodecOptions],
-    ) -> DecodedArray:
+    ) -> ArrayData:
         """Read and decode a single subchunk (inner chunk) of a sharded array.
 
         `subchunk_indices` index the subchunk grid (see `subchunk_grid_shape`).
@@ -1088,7 +1088,7 @@ class AsyncArray:
     @property
     def subset_all(self) -> tuple[slice, ...]:
         """The array subset that spans the entire array, as a tuple of slices."""
-    async def __getitem__(self, selection: Selection) -> DecodedArray:
+    async def __getitem__(self, selection: Selection) -> ArrayData:
         """Read a region with numpy-style basic indexing: `await arr[0:10, :, 5]`.
 
         This is sugar for `retrieve_array_subset`.

--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -55,7 +55,12 @@ validation.
 """
 
 class Array:
-    """A Zarr array."""
+    """A Zarr array.
+
+    The array's data stays in the store, which is usually not in memory. A read
+    fetches only the region that you ask for, decodes it, and returns it as
+    [`ArrayData`][zarrista.ArrayData].
+    """
 
     @staticmethod
     def open(store: FilesystemStore | MemoryStore, path: str = "/") -> Array:
@@ -579,7 +584,12 @@ class Array:
         """
 
 class AsyncArray:
-    """A Zarr array backed by an async store."""
+    """A Zarr array backed by an async store.
+
+    The array's data stays in the store, which is usually not in memory. A read
+    fetches only the region that you ask for, decodes it, and returns it as
+    [`ArrayData`][zarrista.ArrayData].
+    """
 
     @staticmethod
     async def open_async(store: AsyncStore, path: str = "/") -> AsyncArray:

--- a/python/zarrista/_array_bytes.pyi
+++ b/python/zarrista/_array_bytes.pyi
@@ -1,7 +1,10 @@
 from collections.abc import Buffer
 
 class ArrayBytes:
-    """Chunk bytes as input to or output from a codec.
+    """In-memory chunk bytes, as input to or output from a codec.
+
+    The bytes are untyped: they carry no data type and no shape. Compare to
+    [`ArrayData`][zarrista.ArrayData], the typed analog to `ArrayBytes`.
 
     The object holds a data buffer. It can also hold the element byte offsets
     for variable-length data, and a validity mask.

--- a/python/zarrista/_array_data.pyi
+++ b/python/zarrista/_array_data.pyi
@@ -198,8 +198,8 @@ class MaskedVariableArray:
     def dtype(self) -> DataType:
         """The Zarr data type."""
 
-DecodedArray: TypeAlias = Tensor | VariableArray | MaskedTensor | MaskedVariableArray
-"""The result of a read: one of the four decoded array layouts.
+ArrayData: TypeAlias = Tensor | VariableArray | MaskedTensor | MaskedVariableArray
+"""In-memory array data: one of the four layouts a read can return.
 
 The layout depends on the byte layout of the data type. A data type is either
 fixed-width or variable-length, and it either carries a validity mask or does

--- a/python/zarrista/_array_data.pyi
+++ b/python/zarrista/_array_data.pyi
@@ -199,10 +199,15 @@ class MaskedVariableArray:
         """The Zarr data type."""
 
 ArrayData: TypeAlias = Tensor | VariableArray | MaskedTensor | MaskedVariableArray
-"""In-memory array data: one of the four layouts a read can return.
+"""In-memory array data, with its data type and shape.
 
-The layout depends on the byte layout of the data type. A data type is either
-fixed-width or variable-length, and it either carries a validity mask or does
-not. Use `isinstance` to narrow to a concrete type before you use a method that
-belongs to one layout.
+An [`Array`][zarrista.Array]/[`AsyncArray`][zarrista.AsyncArray] is a Zarr array that
+keeps its data in its `store`. It often references larger-than-memory data.
+
+An `ArrayData` is a typed piece of that data in memory.
+
+A read returns one of four layouts. The layout depends on the byte layout of
+the data type. A data type is either fixed-width or variable-length, and it
+either carries a validity mask or does not. Use `isinstance` to narrow to a
+concrete type before you use a method that belongs to one layout.
 """

--- a/python/zarrista/_encoded_chunk.pyi
+++ b/python/zarrista/_encoded_chunk.pyi
@@ -3,7 +3,7 @@ from typing import Unpack
 
 from zarrista.codec import CodecChain, CodecOptions
 
-from ._decoded_array import DecodedArray
+from ._array_data import ArrayData
 from ._dtype import DataType
 from ._fill_value import FillValue
 from ._thread_pool import ThreadPool
@@ -49,7 +49,7 @@ class EncodedChunk:
     @property
     def shape(self) -> list[int]:
         """The shape of the decoded chunk, in elements along each dimension."""
-    def decode(self, **codec_options: Unpack[CodecOptions]) -> DecodedArray:
+    def decode(self, **codec_options: Unpack[CodecOptions]) -> ArrayData:
         """Decode the chunk bytes on the calling thread.
 
         The method releases the GIL while it decodes. Other Python threads can
@@ -70,7 +70,7 @@ class EncodedChunk:
         *,
         pool: ThreadPool | None = None,
         **codec_options: Unpack[CodecOptions],
-    ) -> DecodedArray:
+    ) -> ArrayData:
         """Decode the chunk bytes on a Rust thread pool.
 
         The method does the work on a thread pool and does not hold the GIL.

--- a/python/zarrista/_zarrista.pyi
+++ b/python/zarrista/_zarrista.pyi
@@ -1,9 +1,9 @@
 from ._array import Array, AsyncArray
 from ._array_bytes import ArrayBytes
+from ._array_data import MaskedTensor, MaskedVariableArray, Tensor, VariableArray
 from ._builder import ArrayBuilder
 from ._chunk_key_encoding import ChunkKeyEncoding
 from ._chunks import ChunkGrid
-from ._decoded_array import MaskedTensor, MaskedVariableArray, Tensor, VariableArray
 from ._dtype import DataType
 from ._encoded_chunk import EncodedChunk
 from ._fill_value import FillValue

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -16,7 +16,7 @@ use crate::array::shared::shared_array_methods;
 use crate::array::{PyChunkIndices, PyEncodedChunk};
 use crate::array_bytes::PyArrayBytes;
 use crate::codec::{CodecChainSubchunkExt, PyCodecOptions};
-use crate::data::{DecodedArray, PyDataInput};
+use crate::data::{ArrayData, PyDataInput};
 use crate::error::{ZarristaError, ZarristaResult};
 use crate::metadata::PyArrayMetadata;
 use crate::node::PyNodePath;
@@ -184,7 +184,7 @@ impl PyAsyncArray {
         })
     }
 
-    /// Read a region of the array as `Data`, using numpy-style basic indexing.
+    /// Read a region of the array as `ArrayData`, using numpy-style basic indexing.
     fn retrieve_array_subset<'py>(
         &self,
         py: Python<'py>,
@@ -195,7 +195,7 @@ impl PyAsyncArray {
 
         future_into_py(py, async move {
             let decoded = inner
-                .async_retrieve_array_subset::<DecodedArray>(&array_subset)
+                .async_retrieve_array_subset::<ArrayData>(&array_subset)
                 .await
                 .map_err(ZarristaError::from)?;
             Ok(decoded)
@@ -216,7 +216,7 @@ impl PyAsyncArray {
 
         future_into_py(py, async move {
             let decoded = inner
-                .async_retrieve_chunk_opt::<DecodedArray>(&chunk_indices, &codec_options)
+                .async_retrieve_chunk_opt::<ArrayData>(&chunk_indices, &codec_options)
                 .await
                 .map_err(ZarristaError::from)?;
             Ok(decoded)
@@ -302,7 +302,7 @@ impl PyAsyncArray {
         let inner = self.inner.clone();
         future_into_py(py, async move {
             let decoded = inner
-                .async_retrieve_subchunk_opt::<DecodedArray>(
+                .async_retrieve_subchunk_opt::<ArrayData>(
                     &subchunk_cache,
                     &subchunk_indices,
                     &codec_options,

--- a/src/array/encoded_chunk.rs
+++ b/src/array/encoded_chunk.rs
@@ -12,7 +12,7 @@ use zarrs::array::{
 
 use crate::array::PyFillValue;
 use crate::codec::{PyCodecChain, PyCodecOptions};
-use crate::data::DecodedArray;
+use crate::data::ArrayData;
 use crate::dtype::PyDataType;
 use crate::error::ZarristaResult;
 #[cfg(feature = "async")]
@@ -52,7 +52,7 @@ impl PyEncodedChunk {
         }
     }
 
-    fn _decode(&self, codec_options: &CodecOptions) -> Result<DecodedArray, ArrayError> {
+    fn _decode(&self, codec_options: &CodecOptions) -> Result<ArrayData, ArrayError> {
         let bytes = self.codecs.decode(
             Cow::Borrowed(&self.bytes),
             &self.shape,
@@ -61,7 +61,7 @@ impl PyEncodedChunk {
             codec_options,
         )?;
         let shape = self.shape.iter().map(|v| v.get()).collect::<Vec<_>>();
-        DecodedArray::from_array_bytes(bytes.into_owned(), &shape, &self.data_type)
+        ArrayData::from_array_bytes(bytes.into_owned(), &shape, &self.data_type)
     }
 }
 
@@ -91,7 +91,7 @@ impl PyEncodedChunk {
         &self,
         py: Python,
         codec_options: Option<PyCodecOptions>,
-    ) -> ZarristaResult<DecodedArray> {
+    ) -> ZarristaResult<ArrayData> {
         crate::py::detach(py, || {
             let codec_options = codec_options
                 .map(|opts| opts.into_inner())

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -14,7 +14,7 @@ use crate::array::shared::shared_array_methods;
 use crate::array::{PyChunkIndices, PyEncodedChunk};
 use crate::array_bytes::PyArrayBytes;
 use crate::codec::{CodecChainSubchunkExt, PyCodecOptions};
-use crate::data::{DecodedArray, PyDataInput};
+use crate::data::{ArrayData, PyDataInput};
 use crate::error::ZarristaResult;
 use crate::metadata::PyArrayMetadata;
 use crate::node::PyNodePath;
@@ -59,7 +59,7 @@ shared_array_methods!(PyArray);
 #[pymethods]
 impl PyArray {
     /// Read a region with numpy-style basic indexing, e.g. `arr[0:10, :, 5]`.
-    fn __getitem__(&self, py: Python, selection: PySelection) -> ZarristaResult<DecodedArray> {
+    fn __getitem__(&self, py: Python, selection: PySelection) -> ZarristaResult<ArrayData> {
         self.retrieve_array_subset(py, selection)
     }
 
@@ -147,13 +147,13 @@ impl PyArray {
 
     /// Read a region of the array, using numpy-style basic indexing.
     ///
-    /// Returns one of the decoded result classes (`Tensor`, `VariableArray`,
+    /// Returns one of the `ArrayData` classes (`Tensor`, `VariableArray`,
     /// `MaskedTensor`, `MaskedVariableArray`) depending on the dtype layout.
     fn retrieve_array_subset(
         &self,
         py: Python,
         selection: PySelection,
-    ) -> ZarristaResult<DecodedArray> {
+    ) -> ZarristaResult<ArrayData> {
         crate::py::detach(py, move || {
             let array_subset = self.array_subset(&selection)?;
             Ok(self.inner.retrieve_array_subset(&array_subset)?)
@@ -166,7 +166,7 @@ impl PyArray {
         py: Python,
         chunk_indices: PyChunkIndices,
         codec_options: Option<PyCodecOptions>,
-    ) -> ZarristaResult<DecodedArray> {
+    ) -> ZarristaResult<ArrayData> {
         crate::py::detach(py, move || {
             let codec_options = codec_options
                 .map(|opts| opts.into_inner())
@@ -238,7 +238,7 @@ impl PyArray {
         py: Python,
         subchunk_indices: PyChunkIndices,
         codec_options: Option<PyCodecOptions>,
-    ) -> ZarristaResult<DecodedArray> {
+    ) -> ZarristaResult<ArrayData> {
         crate::py::detach(py, move || {
             let codec_options = codec_options
                 .map(|opts| opts.into_inner())

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,4 +1,4 @@
-//! Decoded array data exposed to Python.
+//! In-memory array data exposed to Python.
 //!
 //! Instead of choosing one preferred representation of decoded array data, such as numpy, or
 //! arrow, or dlpack, we expose the raw post-codec bytes and let consumers choose how to
@@ -39,14 +39,14 @@ use zarrs::array::{ArrayBytes, ArrayError, DataType, FromArrayBytes, data_type};
 /// Internal decoded result, produced by our [`FromArrayBytes`] impl. Carries the
 /// post-codec bytes (zero-copy), the data type, and the region shape (which
 /// zarrs hands us, so we never have to re-derive it).
-pub enum DecodedArray {
+pub enum ArrayData {
     Tensor(PyTensor),
     Variable(PyVariableArray),
     MaskedTensor(PyMaskedTensor),
     MaskedVariable(PyMaskedVariableArray),
 }
 
-impl FromArrayBytes for DecodedArray {
+impl FromArrayBytes for ArrayData {
     fn from_array_bytes(
         bytes: ArrayBytes<'static>,
         shape: &[u64],
@@ -56,11 +56,11 @@ impl FromArrayBytes for DecodedArray {
         let data_type = data_type.clone();
         Ok(match bytes {
             ArrayBytes::Fixed(bytes) => {
-                DecodedArray::Tensor(PyTensor::new(cow_to_bytes(bytes), data_type, shape)?)
+                ArrayData::Tensor(PyTensor::new(cow_to_bytes(bytes), data_type, shape)?)
             }
             ArrayBytes::Variable(v) => {
                 let (buf, offsets) = v.into_parts();
-                DecodedArray::Variable(PyVariableArray::new(
+                ArrayData::Variable(PyVariableArray::new(
                     cow_to_bytes(buf),
                     offsets.to_vec(),
                     data_type,
@@ -70,13 +70,13 @@ impl FromArrayBytes for DecodedArray {
             ArrayBytes::Optional(optional) => {
                 let (data, mask) = optional.into_parts();
                 match *data {
-                    ArrayBytes::Fixed(fixed) => DecodedArray::MaskedTensor(PyMaskedTensor::new(
+                    ArrayBytes::Fixed(fixed) => ArrayData::MaskedTensor(PyMaskedTensor::new(
                         PyTensor::new(cow_to_bytes(fixed), data_type, shape.clone())?,
                         PyTensor::new(cow_to_bytes(mask), data_type::bool(), shape)?,
                     )),
                     ArrayBytes::Variable(variable) => {
                         let (buf, offsets) = variable.into_parts();
-                        DecodedArray::MaskedVariable(PyMaskedVariableArray::new(
+                        ArrayData::MaskedVariable(PyMaskedVariableArray::new(
                             cow_to_bytes(buf),
                             offsets.to_vec(),
                             cow_to_bytes(mask),
@@ -93,17 +93,17 @@ impl FromArrayBytes for DecodedArray {
     }
 }
 
-impl<'py> IntoPyObject<'py> for DecodedArray {
+impl<'py> IntoPyObject<'py> for ArrayData {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
-            DecodedArray::Tensor(py_tensor) => py_tensor.into_bound_py_any(py),
-            DecodedArray::Variable(py_variable_array) => py_variable_array.into_bound_py_any(py),
-            DecodedArray::MaskedTensor(py_masked_tensor) => py_masked_tensor.into_bound_py_any(py),
-            DecodedArray::MaskedVariable(py_masked_variable_array) => {
+            ArrayData::Tensor(py_tensor) => py_tensor.into_bound_py_any(py),
+            ArrayData::Variable(py_variable_array) => py_variable_array.into_bound_py_any(py),
+            ArrayData::MaskedTensor(py_masked_tensor) => py_masked_tensor.into_bound_py_any(py),
+            ArrayData::MaskedVariable(py_masked_variable_array) => {
                 py_masked_variable_array.into_bound_py_any(py)
             }
         }

--- a/src/py.rs
+++ b/src/py.rs
@@ -6,7 +6,7 @@
 /// zarrs-derived type. `Python::detach` bounds both the closure and its return
 /// type by `Ungil`, which implies `Send`. zarrs relaxes its `Send`/`Sync`
 /// bounds on `wasm32`, so a return type as ordinary as
-/// `ZarristaResult<DecodedArray>` does not satisfy that bound there:
+/// `ZarristaResult<ArrayData>` does not satisfy that bound there:
 /// `ZarristaError` holds a `CodecError`, which holds a `DataType`, which is an
 /// `Arc<dyn DataTypeTraits>`.
 ///


### PR DESCRIPTION
Rename `DecodedArray` to `ArrayData` to be more consistent in the naming across our codebase.

- `Array`: a (usually) out of memory Zarr typed array
- `ArrayBytes`: in-memory untyped bytes
- `ArrayData`: in-memory typed array data