### PR TITLE
feat: Add method to change the `attrs` on an Array

### DIFF
--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Buffer
+from collections.abc import Buffer, Mapping
 from types import EllipsisType
 from typing import Protocol, TypeAlias, Unpack
 
@@ -98,7 +98,12 @@ class Array:
         """
     @property
     def attrs(self) -> dict[str, JSONValue]:
-        """The array's user attributes as a dict."""
+        """The array's user attributes as a dict.
+
+        This is a copy. Changing the returned dict does not change the array.
+        Use [`Array.with_attrs`][zarrista.Array.with_attrs] to set the
+        attributes.
+        """
     @property
     def chunk_grid(self) -> ChunkGrid:
         """The chunk grid of the array."""
@@ -522,6 +527,44 @@ class Array:
         Returns:
             A new array reference that uses `chunk_grid`.
         """
+    def with_attrs(self, attrs: Mapping[str, JSONValue]) -> Array:
+        """Return a new array reference with `attrs`, leaving this one unchanged.
+
+        The new attributes replace the old ones. Any key that `attrs` does not
+        contain is gone from the new array reference. To keep the existing
+        attributes, merge them yourself:
+
+        ```py
+        array = array.with_attrs({**array.attrs, "units": "m"})
+        ```
+
+        Nothing is persisted to the store. Call
+        [`Array.store_metadata`][zarrista.Array.store_metadata] to persist the new
+        attributes to the store:
+
+        ```py
+        array = array.with_attrs({"units": "m"})
+        array.store_metadata()
+        ```
+
+        This array is unaffected and remains usable; it simply goes on describing
+        the old attributes. Rebinding, as above, is the intended usage.
+
+        [`Array.store_metadata`][zarrista.Array.store_metadata] adds a `_zarrs`
+        key that records the zarrs version. An array that you read back from a
+        store therefore holds one attribute that you did not set here.
+
+        Args:
+            attrs: The user attributes of the new array reference. Each value
+                must be JSON-serializable.
+
+        Returns:
+            A new array reference that uses `attrs`.
+
+        Raises:
+            TypeError: If a key is not a string, or if a value is not
+                JSON-serializable.
+        """
     def with_shape(self, shape: list[int]) -> Array:
         """Return a new array reference with `shape`, leaving this one unchanged.
 
@@ -656,7 +699,12 @@ class AsyncArray:
         """
     @property
     def attrs(self) -> dict[str, JSONValue]:
-        """The array's user attributes as a dict."""
+        """The array's user attributes as a dict.
+
+        This is a copy. Changing the returned dict does not change the array.
+        Use [`AsyncArray.with_attrs`][zarrista.AsyncArray.with_attrs] to set the
+        attributes.
+        """
     @property
     def chunk_grid(self) -> ChunkGrid:
         """The chunk grid of the array."""
@@ -1082,6 +1130,45 @@ class AsyncArray:
 
         Returns:
             A new array reference that uses `chunk_grid`.
+        """
+    def with_attrs(self, attrs: Mapping[str, JSONValue]) -> AsyncArray:
+        """Return a new array reference with `attrs`, leaving this one unchanged.
+
+        The new attributes replace the old ones. Any key that `attrs` does not
+        contain is gone from the new array reference. To keep the existing
+        attributes, merge them yourself:
+
+        ```py
+        array = array.with_attrs({**array.attrs, "units": "m"})
+        ```
+
+        This method is synchronous: it performs no I/O. Nothing is persisted to
+        the store. Call
+        [`AsyncArray.store_metadata`][zarrista.AsyncArray.store_metadata] to
+        persist the new attributes to the store:
+
+        ```py
+        array = array.with_attrs({"units": "m"})
+        await array.store_metadata()
+        ```
+
+        This array is unaffected and remains usable; it simply goes on describing
+        the old attributes. Rebinding, as above, is the intended usage.
+
+        [`AsyncArray.store_metadata`][zarrista.AsyncArray.store_metadata] adds a
+        `_zarrs` key that records the zarrs version. An array that you read back
+        from a store therefore holds one attribute that you did not set here.
+
+        Args:
+            attrs: The user attributes of the new array reference. Each value
+                must be JSON-serializable.
+
+        Returns:
+            A new array reference that uses `attrs`.
+
+        Raises:
+            TypeError: If a key is not a string, or if a value is not
+                JSON-serializable.
         """
     def with_shape(self, shape: list[int]) -> AsyncArray:
         """Return a new array reference with `shape`, leaving this one unchanged.

--- a/src/array/shared.rs
+++ b/src/array/shared.rs
@@ -141,6 +141,14 @@ macro_rules! shared_array_methods {
                 self.inner.subset_all().into()
             }
 
+            /// Return a new array reference with `attrs`, leaving this one unchanged.
+            fn with_attrs(&self, attrs: $crate::metadata::PyAttributes) -> Self {
+                // Workaround for missing Clone
+                let mut updated = self.inner.with_storage(self.inner.storage());
+                *updated.attributes_mut() = attrs.into_inner();
+                Self::new(::std::sync::Arc::new(updated), self.store.clone())
+            }
+
             /// Return a new array reference with `chunk_grid`, leaving this one unchanged.
             fn with_chunk_grid(
                 &self,

--- a/tests/array/test_with_attrs.py
+++ b/tests/array/test_with_attrs.py
@@ -1,0 +1,61 @@
+"""`Array.with_attrs()` returns a new array with new attributes, without writing."""
+
+import pytest
+from obstore.store import LocalStore
+
+from zarrista import Array, ArrayBuilder, AsyncArray, ChunkGrid, DataType, FillValue
+from zarrista.store import MemoryStore
+
+
+def _builder() -> ArrayBuilder:
+    """A 4x4 int8 array, chunked 2x2, fill 0, with two user attributes."""
+    return ArrayBuilder(
+        ChunkGrid.regular([4, 4], [2, 2]),
+        DataType.from_string("int8"),
+        FillValue(b"\x00"),
+    ).attrs({"units": "m", "long_name": "height"})
+
+
+def test_with_attrs_replaces_attrs_and_leaves_the_original() -> None:
+    array = _builder().create(MemoryStore(), "/a")
+
+    updated = array.with_attrs({"units": "km"})
+
+    # `long_name` is absent, so the new attributes replace rather than merge.
+    assert updated.attrs == {"units": "km"}
+    assert array.attrs == {"units": "m", "long_name": "height"}
+    assert updated.shape == array.shape
+
+
+def test_nothing_is_written_until_store_metadata() -> None:
+    store = MemoryStore()
+    updated = _builder().create(store, "/a").with_attrs({"units": "km"})
+    assert Array.open(store, "/a").attrs["units"] == "m"
+
+    updated.store_metadata()
+
+    stored = Array.open(store, "/a").attrs
+    assert stored["units"] == "km"
+    assert "long_name" not in stored
+    # `store_metadata` also records the zarrs version, which zarrista cannot
+    # yet suppress. Remove this once `ArrayMetadataOptions` is exposed.
+    assert "_zarrs" in stored
+
+
+def test_a_value_that_is_not_json_serializable_raises() -> None:
+    array = _builder().create(MemoryStore(), "/a")
+
+    with pytest.raises(TypeError):
+        array.with_attrs({"bad": object()})
+
+
+async def test_async_with_attrs(tmp_path) -> None:
+    store = LocalStore(str(tmp_path))
+    array = await _builder().create_async(store, "/a")
+
+    updated = array.with_attrs({"units": "km"})
+    await updated.store_metadata()
+
+    assert updated.attrs == {"units": "km"}
+    assert array.attrs == {"units": "m", "long_name": "height"}
+    assert (await AsyncArray.open_async(store, "/a")).attrs["units"] == "km"


### PR DESCRIPTION
### Change list

- Adds `Array.with_attrs` and `AsyncArray.with_attrs`
- Neither of these mutate in place. You get a new `Array` reference **and** you must manually call `store_metadata` if you want to push those new `attrs` to the remote store.

Closes https://github.com/developmentseed/zarrista/issues/118