### PR TITLE
feat: Export variable-length string dtype to numpy

### DIFF
--- a/python/zarrista/_decoded_array.pyi
+++ b/python/zarrista/_decoded_array.pyi
@@ -109,6 +109,10 @@ class VariableArray:
 
     The class exposes the Arrow PyCapsule interface. Therefore variable-length
     string or bytes data moves without a copy.
+
+    Use `to_numpy` (or `np.asarray`/`np.array`) to get a NumPy array of the
+    `string` data type. NumPy has no variable-width binary data type, so the
+    `bytes` data type has no NumPy form. Use the Arrow interface for it.
     """
 
     @property
@@ -117,6 +121,43 @@ class VariableArray:
     @property
     def dtype(self) -> DataType:
         """The Zarr data type."""
+    def to_numpy(self) -> NDArray[Any]:
+        """Copy Zarr data to a NumPy array.
+
+        Currently all variable-length data types must be copied into NumPy buffers.
+
+        Returns:
+            A NumPy array with the same shape as this array, of the
+            `numpy.dtypes.StringDType` data type.
+
+        Raises:
+            NotImplementedError: If the data type is not `string`.
+            UnicodeDecodeError: If the decoded bytes are not valid UTF-8.
+
+        Examples:
+            >>> array[:].to_numpy()
+            array(['a', 'bb', 'ccc'], dtype=StringDType())
+        """
+    def __array__(
+        self,
+        dtype: DTypeLike | None = None,
+        copy: bool | None = None,
+    ) -> NDArray[Any]:
+        """Return a NumPy array, for `np.asarray` and `np.array`.
+
+        Args:
+            dtype: The data type of the result.
+            copy: Whether to copy the data. This method always copies, so `False` is an
+                error.
+
+        Returns:
+            A NumPy array with the same shape as this array.
+
+        Raises:
+            NotImplementedError: If the data type is not `string`.
+            UnicodeDecodeError: If the decoded bytes are not valid UTF-8.
+            ValueError: If `copy` is `False`. This method cannot avoid a copy.
+        """
     def __arrow_c_schema__(self) -> CapsuleType:
         """Export the Arrow schema as a PyCapsule (Arrow C Data Interface).
 

--- a/python/zarrista/_decoded_array.pyi
+++ b/python/zarrista/_decoded_array.pyi
@@ -107,12 +107,10 @@ class Tensor:
 class VariableArray:
     """Variable-length decoded data (e.g. strings or bytes).
 
-    The class exposes the Arrow PyCapsule interface. Therefore variable-length
-    string or bytes data moves without a copy.
+    The class exposes the Arrow PyCapsule interface: you can access the contained data
+    in any Python library that speaks Arrow without a copy.
 
-    Use `to_numpy` (or `np.asarray`/`np.array`) to get a NumPy array of the
-    `string` data type. NumPy has no variable-width binary data type, so the
-    `bytes` data type has no NumPy form. Use the Arrow interface for it.
+    Use `to_numpy` (or `np.asarray`) to get a NumPy array.
     """
 
     @property

--- a/python/zarrista/_decoded_array.pyi
+++ b/python/zarrista/_decoded_array.pyi
@@ -122,7 +122,8 @@ class VariableArray:
     def to_numpy(self) -> NDArray[Any]:
         """Copy Zarr data to a NumPy array.
 
-        Currently all variable-length data types must be copied into NumPy buffers.
+        Currently all variable-length data types must be copied into NumPy buffers. No
+        zero-copy data sharing is possible.
 
         Returns:
             A NumPy array with the same shape as this array, of the

--- a/src/data/variable.rs
+++ b/src/data/variable.rs
@@ -5,11 +5,13 @@ use arrow_buffer::{Buffer, OffsetBuffer, ScalarBuffer};
 use arrow_schema::Field;
 use bytes::Bytes;
 use pyo3::exceptions::PyTypeError;
+use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{PyCapsule, PyTuple};
+use pyo3::types::{PyCapsule, PyList, PyString, PyTuple};
 use pyo3_arrow::error::PyArrowResult;
 use pyo3_arrow::ffi::{to_array_pycapsules, to_schema_pycapsule};
 use zarrs::array::DataType;
+use zarrs::array::data_type::{BytesDataType, StringDataType};
 
 use crate::dtype::PyDataType;
 
@@ -38,8 +40,6 @@ impl PyVariableArray {
     /// zero-copy from the `bytes::Bytes`; only the small offsets array is copied
     /// (zarrs `usize` → Arrow `i64`).
     fn to_arrow_array(&self) -> PyArrowResult<ArrayRef> {
-        use zarrs::array::data_type::*;
-
         let values = Buffer::from(self.bytes.clone());
         let offsets = self
             .offsets
@@ -66,8 +66,6 @@ impl PyVariableArray {
     }
 
     fn arrow_data_type(&self) -> PyResult<arrow_schema::DataType> {
-        use zarrs::array::data_type::*;
-
         if self.data_type.is::<StringDataType>() {
             Ok(arrow_schema::DataType::LargeUtf8)
         } else if self.data_type.is::<BytesDataType>() {
@@ -111,6 +109,17 @@ impl PyVariableArray {
     #[getter]
     fn shape(&self) -> &[u64] {
         &self.shape
+    }
+
+    fn to_numpy<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        if self.data_type.is::<StringDataType>() {
+            string_to_numpy(py, &self.bytes, &self.offsets, &self.shape)
+        } else {
+            Err(PyTypeError::new_err(format!(
+                "NumPy export of variable-length data type {} is not supported",
+                self.data_type
+            )))
+        }
     }
 }
 
@@ -160,4 +169,30 @@ impl PyMaskedVariableArray {
     fn dtype(&self) -> PyDataType {
         self.data_type.clone().into()
     }
+}
+
+fn string_to_numpy<'a>(
+    py: Python<'a>,
+    bytes: &Bytes,
+    offsets: &[usize],
+    shape: &[u64],
+) -> PyResult<Bound<'a, PyAny>> {
+    let mut py_bytes = Vec::with_capacity(offsets.len() - 1);
+    offsets.windows(2).try_for_each(|[start, end]| {
+        let s = std::str::from_utf8(&bytes[*start..*end])
+            .map_err(|e| PyTypeError::new_err(e.to_string()))?;
+        py_bytes.push(PyString::new(py, s));
+        Ok(())
+    })?;
+
+    let py_list = PyList::new(py, py_bytes)?;
+    let numpy_mod = py.import(intern!(py, "numpy"))?;
+
+    let kwargs = PyDict::new(py);
+    kwargs.set_item("dtype", numpy_mod.getattr(intern!(py, "object_"))?)?;
+    numpy_mod.call_method(
+        intern!(py, "array"),
+        PyTuple::new(py, vec![py_list])?,
+        Some(&kwargs),
+    )
 }

--- a/src/data/variable.rs
+++ b/src/data/variable.rs
@@ -4,7 +4,7 @@ use arrow_array::{ArrayRef, LargeBinaryArray, LargeStringArray};
 use arrow_buffer::{Buffer, OffsetBuffer, ScalarBuffer};
 use arrow_schema::Field;
 use bytes::Bytes;
-use pyo3::exceptions::PyTypeError;
+use pyo3::exceptions::{PyNotImplementedError, PyTypeError, PyUnicodeDecodeError, PyValueError};
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyList, PyString, PyTuple};
@@ -109,6 +109,27 @@ impl PyVariableArray {
     #[getter]
     fn shape(&self) -> &[u64] {
         &self.shape
+    }
+
+    #[pyo3(signature = (dtype=None, copy=None))]
+    fn __array__<'py>(
+        &self,
+        py: Python<'py>,
+        dtype: Option<Bound<'py, PyAny>>,
+        copy: Option<bool>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        // Currently all variable-length data types must be copied into numpy buffers
+        if copy == Some(false) {
+            return Err(PyValueError::new_err(
+                "cannot return a zero-copy array from variable-length data",
+            ));
+        }
+
+        let array = self.to_numpy(py)?;
+        match dtype {
+            Some(dtype) => array.call_method1(intern!(py, "astype"), (dtype,)),
+            None => Ok(array),
+        }
     }
 
     fn to_numpy<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {

--- a/src/data/variable.rs
+++ b/src/data/variable.rs
@@ -171,28 +171,30 @@ impl PyMaskedVariableArray {
     }
 }
 
-fn string_to_numpy<'a>(
-    py: Python<'a>,
+/// Decode zarr bytes to a NumPy array with dtype `StringDType`
+fn string_to_numpy<'py>(
+    py: Python<'py>,
     bytes: &Bytes,
     offsets: &[usize],
     shape: &[u64],
-) -> PyResult<Bound<'a, PyAny>> {
-    let mut py_bytes = Vec::with_capacity(offsets.len() - 1);
-    offsets.windows(2).try_for_each(|[start, end]| {
-        let s = std::str::from_utf8(&bytes[*start..*end])
-            .map_err(|e| PyTypeError::new_err(e.to_string()))?;
-        py_bytes.push(PyString::new(py, s));
-        Ok(())
-    })?;
+) -> PyResult<Bound<'py, PyAny>> {
+    let mut elements = Vec::with_capacity(offsets.len().saturating_sub(1));
+    for window in offsets.windows(2) {
+        let element = &bytes[window[0]..window[1]];
+        let s = std::str::from_utf8(element)
+            .map_err(|err| PyUnicodeDecodeError::new_err_from_utf8(py, element, err))?;
+        elements.push(PyString::new(py, s));
+    }
 
-    let py_list = PyList::new(py, py_bytes)?;
-    let numpy_mod = py.import(intern!(py, "numpy"))?;
+    let numpy = py.import(intern!(py, "numpy"))?;
+    let string_dtype = numpy
+        .getattr(intern!(py, "dtypes"))?
+        .getattr(intern!(py, "StringDType"))?
+        .call0()?;
 
-    let kwargs = PyDict::new(py);
-    kwargs.set_item("dtype", numpy_mod.getattr(intern!(py, "object_"))?)?;
-    numpy_mod.call_method(
+    let flat = numpy.call_method1(
         intern!(py, "array"),
-        PyTuple::new(py, vec![py_list])?,
-        Some(&kwargs),
-    )
+        (PyList::new(py, elements)?, string_dtype),
+    )?;
+    flat.call_method1(intern!(py, "reshape"), (shape,))
 }

--- a/src/data/variable.rs
+++ b/src/data/variable.rs
@@ -88,20 +88,6 @@ impl PyVariableArray {
 
 #[pymethods]
 impl PyVariableArray {
-    #[getter]
-    fn shape(&self) -> &[u64] {
-        &self.shape
-    }
-
-    #[getter]
-    fn dtype(&self) -> PyDataType {
-        self.data_type.clone().into()
-    }
-
-    fn __arrow_c_schema__<'py>(&self, py: Python<'py>) -> PyArrowResult<Bound<'py, PyCapsule>> {
-        to_schema_pycapsule(py, &self.arrow_field()?)
-    }
-
     #[pyo3(signature = (requested_schema=None))]
     fn __arrow_c_array__<'py>(
         &self,
@@ -111,6 +97,20 @@ impl PyVariableArray {
         let array = self.to_arrow_array()?;
         let field = Arc::new(self.arrow_field()?);
         to_array_pycapsules(py, field, array.as_ref(), requested_schema)
+    }
+
+    fn __arrow_c_schema__<'py>(&self, py: Python<'py>) -> PyArrowResult<Bound<'py, PyCapsule>> {
+        to_schema_pycapsule(py, &self.arrow_field()?)
+    }
+
+    #[getter]
+    fn dtype(&self) -> PyDataType {
+        self.data_type.clone().into()
+    }
+
+    #[getter]
+    fn shape(&self) -> &[u64] {
+        &self.shape
     }
 }
 

--- a/src/data/variable.rs
+++ b/src/data/variable.rs
@@ -115,7 +115,7 @@ impl PyVariableArray {
         if self.data_type.is::<StringDataType>() {
             string_to_numpy(py, &self.bytes, &self.offsets, &self.shape)
         } else {
-            Err(PyTypeError::new_err(format!(
+            Err(PyNotImplementedError::new_err(format!(
                 "NumPy export of variable-length data type {} is not supported",
                 self.data_type
             )))

--- a/tests/data/test_variable.py
+++ b/tests/data/test_variable.py
@@ -1,0 +1,97 @@
+"""NumPy export from `VariableArray`.
+
+A variable-length array written with zarr-python is read back with zarrista and
+converted to NumPy. Only the `string` data type has a NumPy form.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+
+from zarrista import Array, VariableArray
+from zarrista.store import FilesystemStore
+
+
+def _variable_array(path: Path, values: np.ndarray, dtype: str) -> VariableArray:
+    z = zarr.create_array(
+        store=str(path),
+        shape=values.shape,
+        chunks=values.shape,
+        dtype=dtype,
+    )
+    z[:] = values
+    array = Array.open(FilesystemStore(path))[:]
+    assert isinstance(array, VariableArray)
+    return array
+
+
+def test_to_numpy_gives_string_dtype(tmp_path: Path):
+    values = ["a", "bb", "ccc", "dddd"]
+    array = _variable_array(
+        tmp_path / "s.zarr",
+        np.array(values, dtype=object),
+        "string",
+    )
+
+    result = array.to_numpy()
+
+    assert result.dtype == np.dtypes.StringDType()
+    assert result.tolist() == values
+
+
+def test_to_numpy_keeps_shape(tmp_path: Path):
+    values = np.array([["a", "bb"], ["ccc", "dddd"]], dtype=object)
+    array = _variable_array(tmp_path / "s.zarr", values, "string")
+
+    assert array.to_numpy().tolist() == values.tolist()
+
+
+def test_array_protocol_casts_to_requested_dtype(tmp_path: Path):
+    values = np.array(["a", "bb"], dtype=object)
+    array = _variable_array(tmp_path / "s.zarr", values, "string")
+
+    assert np.asarray(array, dtype=object).dtype == np.dtype(object)
+
+
+def test_array_protocol_rejects_zero_copy(tmp_path: Path):
+    # Building a StringDType array always allocates its own arena, so `copy=False`
+    # can never be honoured.
+    array = _variable_array(
+        tmp_path / "s.zarr",
+        np.array(["a"], dtype=object),
+        "string",
+    )
+
+    with pytest.raises(ValueError, match="zero-copy"):
+        np.array(array, copy=False)
+
+
+def test_to_numpy_rejects_bytes_dtype(tmp_path: Path):
+    # NumPy has no variable-width binary data type.
+    values = np.array([b"a", b"bb"], dtype=object)
+    array = _variable_array(tmp_path / "b.zarr", values, "bytes")
+
+    with pytest.raises(NotImplementedError, match="not supported"):
+        array.to_numpy()
+
+
+def test_to_numpy_rejects_invalid_utf8(tmp_path: Path):
+    # Zarr defines `string` as UTF-8, but nothing on the read path enforces it,
+    # so a corrupt store must fail loudly rather than produce broken text.
+    path = tmp_path / "s.zarr"
+    z = zarr.create_array(
+        store=str(path),
+        shape=(1,),
+        chunks=(1,),
+        dtype="string",
+        compressors=None,
+    )
+    z[:] = np.array(["ab"], dtype=object)
+
+    chunk = next(p for p in path.rglob("*") if p.is_file() and p.name != "zarr.json")
+    chunk.write_bytes(chunk.read_bytes().replace(b"ab", b"\xffb"))
+
+    with pytest.raises(UnicodeDecodeError):
+        Array.open(FilesystemStore(path))[:].to_numpy()


### PR DESCRIPTION
Support exporting the variable-length string dtype to numpy via `to_numpy` and `__array__`