### PR TITLE
feat: Support machine-learning dtypes with microfloat feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,6 +2635,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "microfloat"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a458bd61ee9aaf2e541a8a2ba7f8446755db4892378bd6231aeb65dad385ce"
+dependencies = [
+ "bytemuck",
+ "getrandom 0.3.4",
+ "libm",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5181,6 +5192,7 @@ dependencies = [
  "libz-sys",
  "log",
  "lru",
+ "microfloat",
  "moka",
  "ndarray",
  "num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,12 @@ rayon = "1.12.0"
 serde_json = "1"
 thiserror = "2.0.18"
 tokio-rayon = { version = "2.1", optional = true }
-zarrs = { version = "0.23", features = ["bitround", "ndarray", "sharding"] }
+zarrs = { version = "0.23", features = [
+    "bitround",
+    "microfloat",
+    "ndarray",
+    "sharding",
+] }
 zarrs_icechunk = { version = "0.5", optional = true }
 zarrs_object_store = { version = "0.6.2", optional = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "icechunk<2 ; python_version < '3.12'",
     "ipykernel>=7.3.0",
     "maturin>=1.12",
+    "ml-dtypes>=0.5",
     "numpy>=2.4.6",
     "obstore>=0.10.1",
     "pydoclint>=0.9",

--- a/tests/test_ml_dtypes.py
+++ b/tests/test_ml_dtypes.py
@@ -1,0 +1,172 @@
+"""Reading the machine-learning float and sub-byte integer data types.
+
+zarrs decodes these through its `microfloat` feature. NumPy has no built-in
+equivalents, so `ml_dtypes` supplies them. Importing `ml_dtypes` registers the
+data type names with NumPy, which is what lets `Tensor.to_numpy` resolve a name
+such as `bfloat16`.
+
+zarr-python does not register these data types, so this module registers minimal
+`ZDType` shims to write the fixtures. The shims use `zarr.core.dtype`, which is
+an internal zarr-python API and may change between releases.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar, Self
+
+import ml_dtypes
+import numpy as np
+import pytest
+import zarr
+from zarr.core.dtype import data_type_registry
+from zarr.core.dtype.common import DataTypeValidationError, HasEndianness, HasItemSize
+from zarr.core.dtype.wrapper import ZDType
+
+from zarrista import Array, Tensor
+from zarrista.store import FilesystemStore
+
+# Every data type that zarrs and `ml_dtypes` both name identically, mapped to
+# whether its fill value is an integer. zarrs also has `complex_bfloat16`, which
+# `ml_dtypes` does not provide.
+ML_DTYPES = {
+    "bfloat16": False,
+    "float4_e2m1fn": False,
+    "float6_e2m3fn": False,
+    "float6_e3m2fn": False,
+    "float8_e3m4": False,
+    "float8_e4m3": False,
+    "float8_e4m3b11fnuz": False,
+    "float8_e4m3fnuz": False,
+    "float8_e5m2": False,
+    "float8_e5m2fnuz": False,
+    "float8_e8m0fnu": False,
+    "int2": True,
+    "int4": True,
+    "uint2": True,
+    "uint4": True,
+}
+
+
+@dataclass(frozen=True, kw_only=True)
+class _MLDType(ZDType[Any, Any], HasEndianness, HasItemSize):
+    """Minimal shim that lets zarr-python write an `ml_dtypes` fixture."""
+
+    _native: ClassVar[np.dtype]
+    _integral: ClassVar[bool]
+
+    @property
+    def item_size(self) -> int:
+        return self._native.itemsize
+
+    @classmethod
+    def from_native_dtype(cls, dtype) -> Self:
+        if dtype == cls._native:
+            return cls()
+        raise DataTypeValidationError(f"{dtype} is not {cls._zarr_v3_name}")
+
+    def to_native_dtype(self) -> np.dtype:
+        return self._native
+
+    @classmethod
+    def _from_json_v3(cls, data) -> Self:
+        if data == cls._zarr_v3_name:
+            return cls()
+        raise DataTypeValidationError(f"{data} is not {cls._zarr_v3_name}")
+
+    @classmethod
+    def _from_json_v2(cls, data) -> Self:  # noqa: ARG003
+        raise DataTypeValidationError(f"{cls._zarr_v3_name} has no zarr v2 form")
+
+    def to_json(self, zarr_format) -> str:
+        if zarr_format == 3:
+            return self._zarr_v3_name
+        raise ValueError(f"{self._zarr_v3_name} is a zarr v3 data type")
+
+    def _check_scalar(self, data) -> bool:  # noqa: ARG002
+        return True
+
+    def cast_scalar(self, data) -> np.generic:
+        return self._native.type(data)
+
+    def default_scalar(self) -> np.generic:
+        return self._native.type(0)
+
+    def from_json_scalar(self, data, *, zarr_format) -> np.generic:  # noqa: ARG002
+        return self._native.type(data)
+
+    def to_json_scalar(self, data, *, zarr_format) -> int | float | str:  # noqa: ARG002
+        # An integer data type needs an integer fill value in the metadata.
+        # `ml_dtypes` reports kind "V" for every type, so the caller states this.
+        if self._integral:
+            return int(data)
+        # Zarr v3 encodes a non-finite float as a string. JSON has no literal
+        # for these. `float8_e8m0fnu` needs this: it has no zero, so its default
+        # fill value is NaN.
+        value = float(data)
+        if np.isnan(value):
+            return "NaN"
+        if np.isinf(value):
+            return "Infinity" if value > 0 else "-Infinity"
+        return value
+
+
+def _register(name: str, *, integral: bool) -> type[_MLDType]:
+    native = np.dtype(getattr(ml_dtypes, name))
+    cls = dataclass(frozen=True, kw_only=True)(
+        type(
+            name,
+            (_MLDType,),
+            {
+                "__annotations__": {},
+                "dtype_cls": type(native),
+                "_zarr_v3_name": name,
+                "_native": native,
+                "_integral": integral,
+            },
+        ),
+    )
+    data_type_registry.register(name, cls)
+    return cls
+
+
+for _name, _integral in ML_DTYPES.items():
+    _register(_name, integral=_integral)
+
+
+def _tensor(path: Path, name: str) -> tuple[Tensor, np.ndarray]:
+    native = np.dtype(getattr(ml_dtypes, name))
+    values = np.arange(1, 5).astype(native)
+    z = zarr.create_array(store=str(path), shape=(4,), chunks=(2,), dtype=native)
+    z[:] = values
+    tensor = Array.open(FilesystemStore(path))[:]
+    assert isinstance(tensor, Tensor)
+    return tensor, values
+
+
+@pytest.mark.parametrize("name", ML_DTYPES)
+def test_round_trip_through_zarr_python(tmp_path: Path, name: str):
+    tensor, values = _tensor(tmp_path / f"{name}.zarr", name)
+
+    assert tensor.dtype.name == name
+    assert tensor.to_numpy().dtype == np.dtype(getattr(ml_dtypes, name))
+    assert (tensor.to_numpy() == values).all()
+
+
+def test_to_numpy_is_zero_copy(tmp_path: Path):
+    # `to_numpy` reads the decoded buffer through `np.frombuffer`, so it is a
+    # view even though the buffer protocol has no format code for these types.
+    tensor, _ = _tensor(tmp_path / "bf.zarr", "bfloat16")
+
+    array = tensor.to_numpy()
+
+    assert not array.flags["OWNDATA"]
+    raw = np.frombuffer(tensor.buffer(), dtype="u1")
+    assert array.__array_interface__["data"][0] == raw.__array_interface__["data"][0]
+
+
+def test_buffer_protocol_rejects_ml_dtype(tmp_path: Path):
+    # PEP 3118 has no format code for bfloat16, so only `to_numpy` works.
+    tensor, _ = _tensor(tmp_path / "bf.zarr", "bfloat16")
+
+    with pytest.raises(BufferError, match="format code"):
+        memoryview(tensor)

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
     "python_full_version < '3.12'",
 ]
 
@@ -656,7 +657,8 @@ name = "icechunk"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
 ]
 dependencies = [
     { name = "zarr", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -1098,6 +1100,47 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a4/b4/5fed370d8ebd96e4e399460a7146ae989263f16588b05a6facd6dbd51e60/mkdocstrings_python-2.0.4.tar.gz", hash = "sha256:58c73c5d358e64e9b1673447663f4a2f8a8941e392e225fc0a0c893758cc452f", size = 199219, upload-time = "2026-06-05T08:13:01.819Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/e3/00ec594aef5f55522e6d373bc2ac53e53a8f5e9ae32f2d6854b0de4270f3/mkdocstrings_python-2.0.4-py3-none-any.whl", hash = "sha256:fd87c173e1e719a85997b6d4f852cdc55f36710e0ed08da3a7bd9abe79c9db00", size = 104790, upload-time = "2026-06-05T08:13:00.393Z" },
+]
+
+[[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/5e/712092cfe7e5eb667b8ad9ca7c54442f21ed7ca8979745f1000e24cf8737/ml_dtypes-0.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6c7ecb74c4bd71db68a6bea1edf8da8c34f3d9fe218f038814fd1d310ac76c90", size = 679734, upload-time = "2025-11-17T22:31:39.223Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cf/912146dfd4b5c0eea956836c01dcd2fce6c9c844b2691f5152aca196ce4f/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc11d7e8c44a65115d05e2ab9989d1e045125d7be8e05a071a48bc76eb6d6040", size = 5056165, upload-time = "2025-11-17T22:31:41.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/19189ea605017473660e43762dc853d2797984b3c7bf30ce656099add30c/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b9a53598f21e453ea2fbda8aa783c20faff8e1eeb0d7ab899309a0053f1483", size = 5034975, upload-time = "2025-11-17T22:31:42.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/24/70bd59276883fdd91600ca20040b41efd4902a923283c4d6edcb1de128d2/ml_dtypes-0.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:7c23c54a00ae43edf48d44066a7ec31e05fdc2eee0be2b8b50dd1903a1db94bb", size = 210742, upload-time = "2025-11-17T22:31:44.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/64230ef14e40aa3f1cb254ef623bf812735e6bec7772848d19131111ac0d/ml_dtypes-0.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:557a31a390b7e9439056644cb80ed0735a6e3e3bb09d67fd5687e4b04238d1de", size = 160709, upload-time = "2025-11-17T22:31:46.557Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
 ]
 
 [[package]]
@@ -2189,7 +2232,8 @@ name = "zarr"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
 ]
 dependencies = [
     { name = "donfig", marker = "python_full_version >= '3.12'" },
@@ -2230,6 +2274,7 @@ dev = [
     { name = "icechunk", version = "2.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "ipykernel" },
     { name = "maturin" },
+    { name = "ml-dtypes" },
     { name = "numpy" },
     { name = "obstore" },
     { name = "pydoclint" },
@@ -2263,6 +2308,7 @@ dev = [
     { name = "icechunk", marker = "python_full_version >= '3.12'", specifier = ">=2.1.2" },
     { name = "ipykernel", specifier = ">=7.3.0" },
     { name = "maturin", specifier = ">=1.12" },
+    { name = "ml-dtypes", specifier = ">=0.5" },
     { name = "numpy", specifier = ">=2.4.6" },
     { name = "obstore", specifier = ">=0.10.1" },
     { name = "pydoclint", specifier = ">=0.9" },


### PR DESCRIPTION
Zarrs supports many obscure floating-point data types: https://docs.rs/zarrs/latest/zarrs/#data-types. It turns out that just by adding the `microfloat` feature, these work with numpy out of the box.

Claude wrote up the tests, and there were no library code changes required.