### PR TITLE
feat: Add read-only zipped-zarr support via zarrs_zip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,6 +956,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1181,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc-fast"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1371,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "deflate64"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
 name = "der"
@@ -2557,6 +2587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,6 +2678,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
 ]
 
 [[package]]
@@ -3588,15 +3634,20 @@ version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b57eb3e2e4969f9526ade88f71f6cfaeb1f80e82047b4b1bfaa480fa3dde87c0"
 dependencies = [
+ "bzip2",
  "chardetng",
  "chrono",
  "crc32fast",
+ "deflate64",
  "encoding_rs",
+ "lzma-rs",
+ "miniz_oxide",
  "oem_cp",
  "oval",
  "ownable",
  "tracing",
  "winnow",
+ "zstd",
 ]
 
 [[package]]
@@ -5276,6 +5327,7 @@ dependencies = [
  "pyo3-object_store",
  "pythonize",
  "rayon",
+ "rc-zip",
  "serde_json",
  "thiserror 2.0.19",
  "tokio-rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,6 +991,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,7 +1022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -1270,12 +1281,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1293,11 +1328,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.118",
 ]
@@ -2941,6 +2987,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oem_cp"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7959d3349f484aec36462f98226983578bf7d33f9b034c32967489c7000e1f"
+dependencies = [
+ "phf 0.11.3",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +3012,33 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "oval"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135cef32720c6746450d910890b0b69bcba2bbf6f85c9f4583df13fe415de828"
+
+[[package]]
+name = "ownable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcba94d1536fcc470287d96fd26356c38da8215fdb9a74285b09621f35d9350"
+dependencies = [
+ "ownable-macro",
+]
+
+[[package]]
+name = "ownable-macro"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb55bccce259ddc119321284d6802b0353e63cad7e8a5af92819ae1db505039"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "p256"
@@ -3038,11 +3120,29 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3480,6 +3580,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d09ee01023de07fa073ce14c37cbe0a9e099c6b0b60a29cf4af6d04d9553fed7"
 dependencies = [
  "rayon",
+]
+
+[[package]]
+name = "rc-zip"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b57eb3e2e4969f9526ade88f71f6cfaeb1f80e82047b4b1bfaa480fa3dde87c0"
+dependencies = [
+ "chardetng",
+ "chrono",
+ "crc32fast",
+ "encoding_rs",
+ "oem_cp",
+ "oval",
+ "ownable",
+ "tracing",
+ "winnow",
 ]
 
 [[package]]
@@ -4001,7 +4118,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5165,6 +5282,7 @@ dependencies = [
  "zarrs",
  "zarrs_icechunk",
  "zarrs_object_store",
+ "zarrs_zip",
 ]
 
 [[package]]
@@ -5378,6 +5496,19 @@ dependencies = [
  "itertools 0.14.0",
  "thiserror 2.0.19",
  "unsafe_cell_slice",
+]
+
+[[package]]
+name = "zarrs_zip"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f896c9460c970826088143e2ce259ce0cf96ae5323bca6aa0c3b97fefbafc2d6"
+dependencies = [
+ "derive_more",
+ "itertools 0.14.0",
+ "rc-zip",
+ "thiserror 2.0.19",
+ "zarrs_storage",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5504,7 +5504,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f896c9460c970826088143e2ce259ce0cf96ae5323bca6aa0c3b97fefbafc2d6"
 dependencies = [
+ "async-trait",
  "derive_more",
+ "futures",
  "itertools 0.14.0",
  "rc-zip",
  "thiserror 2.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ zarrs = { version = "0.23", features = [
 ] }
 zarrs_icechunk = { version = "0.5", optional = true }
 zarrs_object_store = { version = "0.6.2", optional = true }
+zarrs_zip = "0.5"
 
 [dev-dependencies]
 # `auto-initialize` lets `cargo test` start a Python interpreter for `Python::attach`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,14 @@ pyo3-bytes = "0.7.1"
 pyo3-object_store = { version = "0.11.0", default-features = false, optional = true }
 pythonize = "0.29"
 rayon = "1.12.0"
+# Add decompression support to zarrs_zip
+rc-zip = { version = "5", features = [
+    "bzip2",
+    "deflate",
+    "deflate64",
+    "lzma",
+    "zstd",
+] }
 serde_json = "1"
 thiserror = "2.0.18"
 tokio-rayon = { version = "2.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ async = [
     "dep:pyo3-object_store",
     "dep:tokio-rayon",
     "zarrs/async",
+    "zarrs_zip/async",
     "dep:zarrs_icechunk",
     "dep:zarrs_object_store",
 ]

--- a/docs/api/store.md
+++ b/docs/api/store.md
@@ -8,6 +8,18 @@
     options:
       show_bases: false
 
+::: zarrista.store.ZipStore
+    options:
+      show_bases: false
+
+::: zarrista.store.AsyncZipStore
+    options:
+      show_bases: false
+
+::: zarrista.store.SyncStore
+    options:
+      show_bases: false
+
 ::: zarrista.store.AsyncStore
     options:
       show_bases: false

--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -14,7 +14,7 @@ from ._dtype import DataType
 from ._encoded_chunk import EncodedChunk
 from ._fill_value import FillValue
 from ._shard_cache import AsyncShardCache, ShardCache
-from ._store import AsyncStore, FilesystemStore, MemoryStore
+from ._store import AsyncStore, SyncStore
 
 _AxisSelector: TypeAlias = int | slice | EllipsisType
 Selection: TypeAlias = _AxisSelector | tuple[_AxisSelector, ...]
@@ -59,7 +59,7 @@ class Array:
     """A Zarr array."""
 
     @staticmethod
-    def open(store: FilesystemStore | MemoryStore, path: str = "/") -> Array:
+    def open(store: SyncStore, path: str = "/") -> Array:
         """Open the array stored at `path` in `store`.
 
         Args:
@@ -76,7 +76,7 @@ class Array:
     @staticmethod
     def from_metadata(
         metadata: ZarrV3ArrayMetadataJSON,
-        store: FilesystemStore | MemoryStore,
+        store: SyncStore,
         path: str = "/",
     ) -> Array:
         """Use the provided metadata to open a new array at `path` in `store`.
@@ -332,7 +332,7 @@ class Array:
             An empty cache for this array.
         """
     @property
-    def store(self) -> FilesystemStore | MemoryStore:
+    def store(self) -> SyncStore:
         """Retrieve the store backing this array."""
     def store_array_subset(
         self,

--- a/python/zarrista/_builder.pyi
+++ b/python/zarrista/_builder.pyi
@@ -13,7 +13,7 @@ from ._chunk_key_encoding import ChunkKeyEncoding
 from ._chunks import ChunkGrid
 from ._dtype import DataType
 from ._fill_value import FillValue
-from ._store import AsyncStore, FilesystemStore, MemoryStore
+from ._store import AsyncStore, SyncStore
 
 class ArrayBuilder:
     """A chained, immutable builder for creating Zarr arrays.
@@ -197,7 +197,7 @@ class ArrayBuilder:
         Returns:
             A new builder with the subchunk shape set.
         """
-    def create(self, store: FilesystemStore | MemoryStore, path: str) -> Array:
+    def create(self, store: SyncStore, path: str) -> Array:
         """Build the array in `store` at `path` and return it.
 
         This **does** write to the store. It stores the array's metadata at

--- a/python/zarrista/_group.pyi
+++ b/python/zarrista/_group.pyi
@@ -5,13 +5,13 @@ from zarr_metadata import (
 )
 
 from ._array import Array, AsyncArray
-from ._store import AsyncStore, FilesystemStore, MemoryStore
+from ._store import AsyncStore, SyncStore
 
 class Group:
     """A Zarr group."""
 
     @staticmethod
-    def open(store: FilesystemStore | MemoryStore, path: str = "/") -> Group:
+    def open(store: SyncStore, path: str = "/") -> Group:
         """Open the group stored at `path` in `store`.
 
         Args:
@@ -108,7 +108,7 @@ class Group:
         This overwrites any metadata that exists at the group's path.
         """
     @property
-    def store(self) -> FilesystemStore | MemoryStore:
+    def store(self) -> SyncStore:
         """Retrieve the store backing this group."""
     def __getitem__(self, name: str) -> Array | Group:
         """Open a direct child array or group by name.

--- a/python/zarrista/_store.pyi
+++ b/python/zarrista/_store.pyi
@@ -4,11 +4,20 @@ from typing import TypeAlias
 from icechunk import Session
 from obstore.store import ObjectStore
 
-AsyncStore: TypeAlias = ObjectStore | Session
+SyncStore: TypeAlias = FilesystemStore | MemoryStore | ZipStore
+"""A store that the sync API accepts.
+
+This is a [`FilesystemStore`][zarrista.store.FilesystemStore], a
+[`MemoryStore`][zarrista.store.MemoryStore], or a
+[`ZipStore`][zarrista.store.ZipStore].
+"""
+
+AsyncStore: TypeAlias = ObjectStore | Session | AsyncZipStore
 """A store that the async API accepts.
 
-This is either an obstore [`ObjectStore`][obstore.store.ObjectStore] or an
-icechunk [`Session`][icechunk.Session]. An `ObjectStore` supports any
+This is an obstore [`ObjectStore`][obstore.store.ObjectStore], an icechunk
+[`Session`][icechunk.Session], or an
+[`AsyncZipStore`][zarrista.store.AsyncZipStore]. An `ObjectStore` supports any
 object-store backend, such as S3, GCS, or the local filesystem. A `Session`
 gives a transactional, versioned store.
 
@@ -36,3 +45,106 @@ class MemoryStore:
     """An in-memory store, primarily useful for testing."""
 
     def __init__(self) -> None: ...
+
+class ZipStore:
+    """A read-only store backed by a zip file that another store holds.
+
+    The store reads the zip metadata when you open it, and then serves each Zarr
+    key from an entry in the zip file. Every write operation fails, because a
+    zip file cannot be modified in place.
+
+    The store reads entries that use the stored, deflate, deflate64, bzip2,
+    lzma, or zstd compression method. `zarr-python` writes a zip store with the
+    stored method by default.
+
+    Examples:
+        Open a Zarr array that is held in a local zip file:
+
+        >>> from zarrista import Array
+        >>> from zarrista.store import FilesystemStore, ZipStore
+        >>> backing = FilesystemStore("/data")
+        >>> store = ZipStore(backing, "archive.zip")
+        >>> array = Array.open(store)
+    """
+
+    def __init__(
+        self,
+        store: SyncStore,
+        key: str,
+        path: str | Path | None = None,
+    ) -> None:
+        """Open the zip file that is stored at `key` in `store`.
+
+        Args:
+            store: The store that holds the zip file.
+            key: The store key of the zip file, such as `archive.zip`.
+            path: The directory inside the zip file to use as the root of this
+                store. End the value with `/`, because the store removes this
+                value from the start of each entry name. A value of `None` uses
+                the whole zip file.
+
+        Raises:
+            StorageError: If `store` holds no value at `key`, or if that value
+                is not a valid zip file.
+            ValueError: If `key` is not a valid store key.
+        """
+
+    @staticmethod
+    def open(
+        store: SyncStore,
+        key: str,
+        path: str | Path | None = None,
+    ) -> ZipStore:
+        """Open the zip file that is stored at `key` in `store`.
+
+        This is an alias for [`ZipStore`][zarrista.store.ZipStore].
+
+        Args:
+            store: The store that holds the zip file.
+            key: The store key of the zip file, such as `archive.zip`.
+            path: The directory inside the zip file to use as the root of this
+                store. End the value with `/`, because the store removes this
+                value from the start of each entry name. A value of `None` uses
+                the whole zip file.
+
+        Returns:
+            The store for the zip file at `key`.
+
+        Raises:
+            StorageError: If `store` holds no value at `key`, or if that value
+                is not a valid zip file.
+            ValueError: If `key` is not a valid store key.
+        """
+
+class AsyncZipStore:
+    """A read-only store backed by a zip file that another async store holds.
+
+    This is the async form of [`ZipStore`][zarrista.store.ZipStore]. Use it with
+    [`AsyncArray`][zarrista.AsyncArray] and
+    [`AsyncGroup`][zarrista.AsyncGroup].
+    """
+
+    @staticmethod
+    async def open(
+        store: AsyncStore,
+        key: str,
+        path: str | Path | None = None,
+    ) -> AsyncZipStore:
+        """Open the zip file that is stored at `key` in `store`.
+
+        Args:
+            store: The async store that holds the zip file.
+            key: The store key of the zip file, such as `archive.zip`.
+            path: The directory inside the zip file to use as the root of this
+                store. End the value with `/`, because the store removes this
+                value from the start of each entry name. A value of `None` uses
+                the whole zip file.
+
+        Returns:
+            The store for the zip file at `key`.
+
+        Raises:
+            StorageError: If `store` holds no value at `key`, or if that value
+                is not a valid zip file.
+            ValueError: If `key` is not a valid store key.
+        """

--- a/python/zarrista/_store.pyi
+++ b/python/zarrista/_store.pyi
@@ -126,7 +126,7 @@ class AsyncZipStore:
     """
 
     @staticmethod
-    async def open(
+    async def open_async(
         store: AsyncStore,
         key: str,
         *,

--- a/python/zarrista/_store.pyi
+++ b/python/zarrista/_store.pyi
@@ -50,12 +50,9 @@ class ZipStore:
     """A read-only store backed by a zip file that another store holds.
 
     The store reads the zip metadata when you open it, and then serves each Zarr
-    key from an entry in the zip file. Every write operation fails, because a
-    zip file cannot be modified in place.
+    key from an entry in the zip file.
 
-    The store reads entries that use the stored, deflate, deflate64, bzip2,
-    lzma, or zstd compression method. `zarr-python` writes a zip store with the
-    stored method by default.
+    This store is read only and does not support writing.
 
     Examples:
         Open a Zarr array that is held in a local zip file:
@@ -71,7 +68,8 @@ class ZipStore:
         self,
         store: SyncStore,
         key: str,
-        path: str | Path | None = None,
+        *,
+        path: str | None = None,
     ) -> None:
         """Open the zip file that is stored at `key` in `store`.
 
@@ -79,9 +77,9 @@ class ZipStore:
             store: The store that holds the zip file.
             key: The store key of the zip file, such as `archive.zip`.
             path: The directory inside the zip file to use as the root of this
-                store. End the value with `/`, because the store removes this
-                value from the start of each entry name. A value of `None` uses
-                the whole zip file.
+                store. A value of `None` uses the whole zip file. The store
+                accepts `nested`, `nested/`, and `/nested/` as the same
+                directory.
 
         Raises:
             StorageError: If `store` holds no value at `key`, or if that value
@@ -93,7 +91,8 @@ class ZipStore:
     def open(
         store: SyncStore,
         key: str,
-        path: str | Path | None = None,
+        *,
+        path: str | None = None,
     ) -> ZipStore:
         """Open the zip file that is stored at `key` in `store`.
 
@@ -103,9 +102,9 @@ class ZipStore:
             store: The store that holds the zip file.
             key: The store key of the zip file, such as `archive.zip`.
             path: The directory inside the zip file to use as the root of this
-                store. End the value with `/`, because the store removes this
-                value from the start of each entry name. A value of `None` uses
-                the whole zip file.
+                store. A value of `None` uses the whole zip file. The store
+                accepts `nested`, `nested/`, and `/nested/` as the same
+                directory.
 
         Returns:
             The store for the zip file at `key`.
@@ -122,13 +121,16 @@ class AsyncZipStore:
     This is the async form of [`ZipStore`][zarrista.store.ZipStore]. Use it with
     [`AsyncArray`][zarrista.AsyncArray] and
     [`AsyncGroup`][zarrista.AsyncGroup].
+
+    This store is read only and does not support writing.
     """
 
     @staticmethod
     async def open(
         store: AsyncStore,
         key: str,
-        path: str | Path | None = None,
+        *,
+        path: str | None = None,
     ) -> AsyncZipStore:
         """Open the zip file that is stored at `key` in `store`.
 
@@ -136,9 +138,9 @@ class AsyncZipStore:
             store: The async store that holds the zip file.
             key: The store key of the zip file, such as `archive.zip`.
             path: The directory inside the zip file to use as the root of this
-                store. End the value with `/`, because the store removes this
-                value from the start of each entry name. A value of `None` uses
-                the whole zip file.
+                store. A value of `None` uses the whole zip file. The store
+                accepts `nested`, `nested/`, and `/nested/` as the same
+                directory.
 
         Returns:
             The store for the zip file at `key`.

--- a/python/zarrista/_zarrista.pyi
+++ b/python/zarrista/_zarrista.pyi
@@ -9,7 +9,7 @@ from ._encoded_chunk import EncodedChunk
 from ._fill_value import FillValue
 from ._group import AsyncGroup, Group
 from ._shard_cache import AsyncShardCache, ShardCache
-from ._store import FilesystemStore, MemoryStore
+from ._store import AsyncZipStore, FilesystemStore, MemoryStore, ZipStore
 from ._thread_pool import ThreadPool
 
 __version__: str
@@ -21,6 +21,7 @@ __all__ = [
     "AsyncArray",
     "AsyncGroup",
     "AsyncShardCache",
+    "AsyncZipStore",
     "ChunkGrid",
     "ChunkKeyEncoding",
     "DataType",
@@ -35,5 +36,6 @@ __all__ = [
     "Tensor",
     "ThreadPool",
     "VariableArray",
+    "ZipStore",
     "__version__",
 ]

--- a/python/zarrista/store.py
+++ b/python/zarrista/store.py
@@ -8,6 +8,14 @@ if TYPE_CHECKING:
     from icechunk import Session
     from obstore.store import ObjectStore
 
+SyncStore: TypeAlias = FilesystemStore | MemoryStore | ZipStore
+"""A store that the sync API accepts.
+
+This is a [`FilesystemStore`][zarrista.store.FilesystemStore], a
+[`MemoryStore`][zarrista.store.MemoryStore], or a
+[`ZipStore`][zarrista.store.ZipStore].
+"""
+
 # Note: this is a string so that icechunk and obstore can be optional dependencies
 AsyncStore: TypeAlias = "ObjectStore | Session"
 """A store that the async API accepts.

--- a/python/zarrista/store.py
+++ b/python/zarrista/store.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, TypeAlias
 
-from ._zarrista import FilesystemStore, MemoryStore
+from ._zarrista import AsyncZipStore, FilesystemStore, MemoryStore, ZipStore
 
 if TYPE_CHECKING:
     from icechunk import Session
@@ -17,11 +17,12 @@ This is a [`FilesystemStore`][zarrista.store.FilesystemStore], a
 """
 
 # Note: this is a string so that icechunk and obstore can be optional dependencies
-AsyncStore: TypeAlias = "ObjectStore | Session"
+AsyncStore: TypeAlias = "ObjectStore | Session | AsyncZipStore"
 """A store that the async API accepts.
 
-This is either an obstore [`ObjectStore`][obstore.store.ObjectStore] or an
-icechunk [`Session`][icechunk.Session]. An `ObjectStore` supports any
+This is an obstore [`ObjectStore`][obstore.store.ObjectStore], an icechunk
+[`Session`][icechunk.Session], or an
+[`AsyncZipStore`][zarrista.store.AsyncZipStore]. An `ObjectStore` supports any
 object-store backend, such as S3, GCS, or the local filesystem. A `Session`
 gives a transactional, versioned store.
 
@@ -34,6 +35,8 @@ data exists only in the Python process, and the reads cannot find it.
 
 
 __all__ = [
+    "AsyncZipStore",
     "FilesystemStore",
     "MemoryStore",
+    "ZipStore",
 ]

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -318,8 +318,8 @@ impl PyAsyncArray {
     }
 
     #[getter]
-    fn store(&self) -> &PyAsyncStorage {
-        &self.store
+    fn store(&self) -> PyAsyncStorage {
+        self.store.clone()
     }
 
     #[pyo3(signature = (selection, data, **codec_options))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,7 @@ use zarrs::group::GroupCreateError;
 use zarrs::node::{NodeCreateError, NodePathError};
 use zarrs::plugin::PluginCreateError;
 use zarrs::storage::StorageError;
+use zarrs_zip::ZipStorageAdapterCreateError;
 
 use crate::exceptions as exc;
 
@@ -60,6 +61,10 @@ pub enum ZarristaError {
     /// Failed to open a filesystem store.
     #[error(transparent)]
     FilesystemStoreCreate(#[from] FilesystemStoreCreateError),
+
+    /// Failed to open a zip store.
+    #[error(transparent)]
+    ZipStoreCreate(#[from] ZipStorageAdapterCreateError),
 
     /// Failed to convert a value to or from Python.
     #[error(transparent)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -112,6 +112,7 @@ impl From<ZarristaError> for PyErr {
             ZarristaError::FilesystemStoreCreate(err) => {
                 exc::StorageError::new_err(err.to_string())
             }
+            ZarristaError::ZipStoreCreate(err) => exc::StorageError::new_err(err.to_string()),
             ZarristaError::Pythonize(err) => exc::SerializationError::new_err(err.to_string()),
             ZarristaError::SerdeJson(err) => exc::SerializationError::new_err(err.to_string()),
             ZarristaError::Codec(err) => exc::CodecError::new_err(err.to_string()),

--- a/src/group/async.rs
+++ b/src/group/async.rs
@@ -218,8 +218,8 @@ impl PyAsyncGroup {
     }
 
     #[getter]
-    fn store(&self) -> &PyAsyncStorage {
-        &self.store
+    fn store(&self) -> PyAsyncStorage {
+        self.store.clone()
     }
 
     /// Write the group metadata to the store.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ mod thread_pool;
 mod wasm;
 
 use pyo3::prelude::*;
+// In cargo.toml only to add decompression support to zarrs_zip
+use rc_zip as _;
 
 use crate::array::{
     PyArray, PyArrayBuilder, PyChunkGrid, PyChunkKeyEncoding, PyEncodedChunk, PyFillValue,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use crate::data::{PyMaskedTensor, PyMaskedVariableArray, PyTensor, PyVariableArr
 use crate::dtype::PyDataType;
 use crate::exceptions::register_exceptions_module;
 use crate::group::PyGroup;
-use crate::storage::{PyFilesystemStore, PyMemoryStore};
+use crate::storage::{PyFilesystemStore, PyMemoryStore, PyZipStore};
 use crate::thread_pool::PyThreadPool;
 
 /// The compiled core of zarrista, imported as `zarrista._zarrista`.
@@ -61,6 +61,7 @@ fn _zarrista(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyTensor>()?;
     m.add_class::<PyThreadPool>()?;
     m.add_class::<PyVariableArray>()?;
+    m.add_class::<PyZipStore>()?;
 
     register_codec_module(m)?;
     register_exceptions_module(m)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ fn _zarrista(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<crate::group::PyAsyncGroup>()?;
     #[cfg(feature = "async")]
     m.add_class::<crate::array::PyAsyncShardCache>()?;
+    #[cfg(feature = "async")]
+    m.add_class::<crate::storage::PyAsyncZipStore>()?;
     m.add_class::<PyChunkGrid>()?;
     m.add_class::<PyChunkKeyEncoding>()?;
     m.add_class::<PyDataType>()?;

--- a/src/storage/async.rs
+++ b/src/storage/async.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -6,6 +7,7 @@ use object_store::ObjectStore;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
+use pyo3_async_runtimes::tokio::future_into_py;
 use pyo3_bytes::PyBytes;
 use pyo3_object_store::AnyObjectStore;
 use zarrs::storage::byte_range::ByteRangeIterator;
@@ -17,11 +19,16 @@ use zarrs::storage::{
 };
 use zarrs_icechunk::AsyncIcechunkStore;
 use zarrs_object_store::AsyncObjectStore;
+use zarrs_zip::ZipStorageAdapter;
 
-#[derive(Clone, IntoPyObject, IntoPyObjectRef)]
+use crate::error::ZarristaError;
+use crate::storage::PyStoreKey;
+
+#[derive(Clone, IntoPyObject)]
 pub enum PyAsyncStorage {
     ObjectStore(PyAsyncObjectStore),
     Icechunk(PyAsyncIcechunkStore),
+    ZipStore(PyAsyncZipStore),
 }
 
 impl PyAsyncStorage {
@@ -29,6 +36,7 @@ impl PyAsyncStorage {
         match self {
             Self::ObjectStore(store) => store.inner.clone(),
             Self::Icechunk(store) => store.inner.clone(),
+            Self::ZipStore(store) => store.storage.clone(),
         }
     }
 }
@@ -46,6 +54,10 @@ impl FromPyObject<'_, '_> for PyAsyncStorage {
 
         if let Ok(store) = obj.extract::<PyAsyncObjectStore>() {
             return Ok(Self::ObjectStore(store));
+        }
+
+        if let Ok(s) = obj.cast::<PyAsyncZipStore>() {
+            return Ok(Self::ZipStore(s.get().clone()));
         }
 
         Err(PyTypeError::new_err(
@@ -182,6 +194,57 @@ impl<'py> IntoPyObject<'py> for &PyAsyncIcechunkStore {
         Ok(self.pyobj.bind(py).clone())
     }
 }
+
+/// A read-only store backed by a zip file that is held in another store.
+#[pyclass(
+    module = "zarrista",
+    frozen,
+    name = "AsyncZipStore",
+    skip_from_py_object
+)]
+#[derive(Clone)]
+pub struct PyAsyncZipStore {
+    storage: Arc<AsyncReadOnlyStorageAdapter>,
+    key: StoreKey,
+}
+
+crate::wasm_send_sync!(PyAsyncZipStore);
+
+#[pymethods]
+impl PyAsyncZipStore {
+    /// Open the zip file that is stored at `key` in `store`.
+    #[staticmethod]
+    #[pyo3(
+        signature = (store, key, path = None),
+        text_signature = "(store, key, path=None)"
+    )]
+    fn open<'py>(
+        py: Python<'py>,
+        store: PyAsyncStorage,
+        key: PyStoreKey,
+        path: Option<PathBuf>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let key = key.into_inner();
+
+        future_into_py(py, async move {
+            let adapter = if let Some(path) = path {
+                ZipStorageAdapter::new_with_path_async(store.inner(), key.clone(), path).await
+            } else {
+                ZipStorageAdapter::new_async(store.inner(), key.clone()).await
+            }
+            .map_err(ZarristaError::from)?;
+            Ok(Self {
+                storage: Arc::new(AsyncReadOnlyStorageAdapter::new(Arc::new(adapter))),
+                key,
+            })
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!("AsyncZipStore({})", self.key.as_str())
+    }
+}
+
 /// An async storage adapter that reads and lists transparently but rejects all writes at runtime.
 pub struct AsyncReadOnlyStorageAdapter(Arc<dyn AsyncReadableListableStorageTraits>);
 

--- a/src/storage/async.rs
+++ b/src/storage/async.rs
@@ -22,7 +22,7 @@ use zarrs_object_store::AsyncObjectStore;
 use zarrs_zip::ZipStorageAdapter;
 
 use crate::error::ZarristaError;
-use crate::storage::PyStoreKey;
+use crate::storage::{PyStoreKey, PyZipPath};
 
 #[derive(Clone, IntoPyObject)]
 pub enum PyAsyncStorage {
@@ -215,14 +215,14 @@ impl PyAsyncZipStore {
     /// Open the zip file that is stored at `key` in `store`.
     #[staticmethod]
     #[pyo3(
-        signature = (store, key, path = None),
-        text_signature = "(store, key, path=None)"
+        signature = (store, key, *, path = None),
+        text_signature = "(store, key, *, path=None)"
     )]
     fn open<'py>(
         py: Python<'py>,
         store: PyAsyncStorage,
         key: PyStoreKey,
-        path: Option<PathBuf>,
+        path: Option<PyZipPath>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let key = key.into_inner();
 

--- a/src/storage/async.rs
+++ b/src/storage/async.rs
@@ -217,7 +217,7 @@ impl PyAsyncZipStore {
         signature = (store, key, *, path = None),
         text_signature = "(store, key, *, path=None)"
     )]
-    fn open<'py>(
+    fn open_async<'py>(
         py: Python<'py>,
         store: PyAsyncStorage,
         key: PyStoreKey,

--- a/src/storage/async.rs
+++ b/src/storage/async.rs
@@ -1,5 +1,4 @@
 use std::convert::Infallible;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,5 +6,5 @@ mod type_wrappers;
 #[cfg(feature = "async")]
 pub use r#async::{AsyncReadOnlyStorageAdapter, PyAsyncStorage};
 pub(crate) use sync::PySyncStorage;
-pub use sync::{PyFilesystemStore, PyMemoryStore, ReadOnlyStorageAdapter};
+pub use sync::{PyFilesystemStore, PyMemoryStore, PyZipStore, ReadOnlyStorageAdapter};
 pub use type_wrappers::PyStoreKey;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7,4 +7,4 @@ mod type_wrappers;
 pub use r#async::{AsyncReadOnlyStorageAdapter, PyAsyncStorage, PyAsyncZipStore};
 pub(crate) use sync::PySyncStorage;
 pub use sync::{PyFilesystemStore, PyMemoryStore, PyZipStore, ReadOnlyStorageAdapter};
-pub use type_wrappers::PyStoreKey;
+pub use type_wrappers::{PyStoreKey, PyZipPath};

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,7 +4,7 @@ mod sync;
 mod type_wrappers;
 
 #[cfg(feature = "async")]
-pub use r#async::{AsyncReadOnlyStorageAdapter, PyAsyncStorage};
+pub use r#async::{AsyncReadOnlyStorageAdapter, PyAsyncStorage, PyAsyncZipStore};
 pub(crate) use sync::PySyncStorage;
 pub use sync::{PyFilesystemStore, PyMemoryStore, PyZipStore, ReadOnlyStorageAdapter};
 pub use type_wrappers::PyStoreKey;

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -21,6 +21,7 @@ use crate::storage::PyStoreKey;
 pub enum PySyncStorage {
     Filesystem(PyFilesystemStore),
     MemoryStore(PyMemoryStore),
+    ZipStore(PyZipStore),
 }
 
 impl PySyncStorage {
@@ -28,6 +29,7 @@ impl PySyncStorage {
         match self {
             Self::Filesystem(store) => store.storage.clone(),
             Self::MemoryStore(store) => store.0.clone(),
+            Self::ZipStore(store) => store.0.clone(),
         }
     }
 }
@@ -42,8 +44,11 @@ impl FromPyObject<'_, '_> for PySyncStorage {
         if let Ok(s) = obj.cast::<PyMemoryStore>() {
             return Ok(Self::MemoryStore(s.get().clone()));
         }
+        if let Ok(s) = obj.cast::<PyZipStore>() {
+            return Ok(Self::ZipStore(s.get().clone()));
+        }
         Err(PyTypeError::new_err(
-            "expected a FilesystemStore or MemoryStore",
+            "expected a FilesystemStore, MemoryStore, or ZipStore",
         ))
     }
 }
@@ -53,51 +58,7 @@ impl From<PySyncStorage> for Arc<dyn ReadableWritableListableStorageTraits> {
         match s {
             PySyncStorage::Filesystem(store) => store.storage,
             PySyncStorage::MemoryStore(store) => store.0,
-        }
-    }
-}
-
-impl ReadableStorageTraits for PySyncStorage {
-    fn get_partial_many<'a>(
-        &'a self,
-        key: &StoreKey,
-        byte_ranges: ByteRangeIterator<'a>,
-    ) -> Result<MaybeBytesIterator<'a>, StorageError> {
-        match self {
-            Self::Filesystem(inner) => inner.storage.get_partial_many(key, byte_ranges),
-            Self::MemoryStore(inner) => inner.0.get_partial_many(key, byte_ranges),
-        }
-    }
-
-    fn size_key(&self, key: &StoreKey) -> Result<Option<u64>, StorageError> {
-        match self {
-            Self::Filesystem(inner) => inner.storage.size_key(key),
-            Self::MemoryStore(inner) => inner.0.size_key(key),
-        }
-    }
-
-    fn get(&self, key: &StoreKey) -> Result<MaybeBytes, StorageError> {
-        match self {
-            Self::Filesystem(inner) => inner.storage.get(key),
-            Self::MemoryStore(inner) => inner.0.get(key),
-        }
-    }
-
-    fn get_partial(
-        &self,
-        key: &StoreKey,
-        byte_range: ByteRange,
-    ) -> Result<MaybeBytes, StorageError> {
-        match self {
-            Self::Filesystem(inner) => inner.storage.get_partial(key, byte_range),
-            Self::MemoryStore(inner) => inner.0.get_partial(key, byte_range),
-        }
-    }
-
-    fn supports_get_partial(&self) -> bool {
-        match self {
-            Self::Filesystem(inner) => inner.storage.supports_get_partial(),
-            Self::MemoryStore(inner) => inner.0.supports_get_partial(),
+            PySyncStorage::ZipStore(store) => store.0,
         }
     }
 }

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -14,7 +14,7 @@ use zarrs::storage::{
 use zarrs_zip::ZipStorageAdapter;
 
 use crate::error::ZarristaResult;
-use crate::storage::PyStoreKey;
+use crate::storage::{PyStoreKey, PyZipPath};
 
 /// A zarrista sync store object adapted to the maximal `zarrs` storage trait.
 #[derive(Clone, IntoPyObject)]
@@ -129,14 +129,14 @@ impl PyZipStore {
     /// Open the zip file that is stored at `key` in `store`.
     #[new]
     #[pyo3(
-        signature = (store, key, path = None),
-        text_signature = "(store, key, path=None)"
+        signature = (store, key, *, path = None),
+        text_signature = "(store, key, *, path=None)"
     )]
     fn new(
         py: Python,
         store: PySyncStorage,
         key: PyStoreKey,
-        path: Option<PathBuf>,
+        path: Option<PyZipPath>,
     ) -> ZarristaResult<Self> {
         let key = key.into_inner();
         let adapter = crate::py::detach(py, || {
@@ -157,14 +157,14 @@ impl PyZipStore {
     /// This is an alias for `ZipStore.__init__`
     #[staticmethod]
     #[pyo3(
-        signature = (store, key, path = None),
-        text_signature = "(store, key, path=None)"
+        signature = (store, key, *, path = None),
+        text_signature = "(store, key, *, path=None)"
     )]
     fn open(
         py: Python,
         store: PySyncStorage,
         key: PyStoreKey,
-        path: Option<PathBuf>,
+        path: Option<PyZipPath>,
     ) -> ZarristaResult<Self> {
         Self::new(py, store, key, path)
     }

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -11,8 +11,10 @@ use zarrs::storage::{
     ReadableListableStorageTraits, ReadableStorageTraits, ReadableWritableListableStorageTraits,
     StorageError, StoreKey, StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorageTraits,
 };
+use zarrs_zip::ZipStorageAdapter;
 
 use crate::error::ZarristaResult;
+use crate::storage::PyStoreKey;
 
 /// A zarrista sync store object adapted to the maximal `zarrs` storage trait.
 #[derive(Clone, IntoPyObject)]
@@ -51,6 +53,51 @@ impl From<PySyncStorage> for Arc<dyn ReadableWritableListableStorageTraits> {
         match s {
             PySyncStorage::Filesystem(store) => store.storage,
             PySyncStorage::MemoryStore(store) => store.0,
+        }
+    }
+}
+
+impl ReadableStorageTraits for PySyncStorage {
+    fn get_partial_many<'a>(
+        &'a self,
+        key: &StoreKey,
+        byte_ranges: ByteRangeIterator<'a>,
+    ) -> Result<MaybeBytesIterator<'a>, StorageError> {
+        match self {
+            Self::Filesystem(inner) => inner.storage.get_partial_many(key, byte_ranges),
+            Self::MemoryStore(inner) => inner.0.get_partial_many(key, byte_ranges),
+        }
+    }
+
+    fn size_key(&self, key: &StoreKey) -> Result<Option<u64>, StorageError> {
+        match self {
+            Self::Filesystem(inner) => inner.storage.size_key(key),
+            Self::MemoryStore(inner) => inner.0.size_key(key),
+        }
+    }
+
+    fn get(&self, key: &StoreKey) -> Result<MaybeBytes, StorageError> {
+        match self {
+            Self::Filesystem(inner) => inner.storage.get(key),
+            Self::MemoryStore(inner) => inner.0.get(key),
+        }
+    }
+
+    fn get_partial(
+        &self,
+        key: &StoreKey,
+        byte_range: ByteRange,
+    ) -> Result<MaybeBytes, StorageError> {
+        match self {
+            Self::Filesystem(inner) => inner.storage.get_partial(key, byte_range),
+            Self::MemoryStore(inner) => inner.0.get_partial(key, byte_range),
+        }
+    }
+
+    fn supports_get_partial(&self) -> bool {
+        match self {
+            Self::Filesystem(inner) => inner.storage.supports_get_partial(),
+            Self::MemoryStore(inner) => inner.0.supports_get_partial(),
         }
     }
 }
@@ -103,6 +150,25 @@ impl PyMemoryStore {
 
     fn __repr__(&self) -> String {
         "MemoryStore()".to_string()
+    }
+}
+
+/// An in-memory store, primarily useful for testing.
+#[pyclass(module = "zarrista", frozen, name = "ZipStore", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyZipStore(Arc<ZipStorageAdapter<PySyncStorage>>);
+
+#[pymethods]
+impl PyZipStore {
+    #[new]
+    #[pyo3(signature = (store, key, path = None))]
+    fn new(store: PySyncStorage, key: PyStoreKey, path: Option<PathBuf>) -> ZarristaResult<Self> {
+        let zip_store = if let Some(path) = path {
+            ZipStorageAdapter::new_with_path(Arc::new(store), key.into(), path)?
+        } else {
+            ZipStorageAdapter::new(Arc::new(store), key.into())?
+        };
+        Ok(Self(Arc::new(zip_store)))
     }
 }
 

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -29,7 +29,7 @@ impl PySyncStorage {
         match self {
             Self::Filesystem(store) => store.storage.clone(),
             Self::MemoryStore(store) => store.0.clone(),
-            Self::ZipStore(store) => store.0.clone(),
+            Self::ZipStore(store) => store.storage.clone(),
         }
     }
 }
@@ -58,7 +58,7 @@ impl From<PySyncStorage> for Arc<dyn ReadableWritableListableStorageTraits> {
         match s {
             PySyncStorage::Filesystem(store) => store.storage,
             PySyncStorage::MemoryStore(store) => store.0,
-            PySyncStorage::ZipStore(store) => store.0,
+            PySyncStorage::ZipStore(store) => store.storage,
         }
     }
 }
@@ -114,22 +114,63 @@ impl PyMemoryStore {
     }
 }
 
-/// An in-memory store, primarily useful for testing.
+/// A read-only store backed by a zip file that is held in another store.
 #[pyclass(module = "zarrista", frozen, name = "ZipStore", skip_from_py_object)]
 #[derive(Clone)]
-pub struct PyZipStore(Arc<ZipStorageAdapter<PySyncStorage>>);
+pub struct PyZipStore {
+    storage: Arc<ReadOnlyStorageAdapter>,
+    key: StoreKey,
+}
+
+crate::wasm_send_sync!(PyZipStore);
 
 #[pymethods]
 impl PyZipStore {
+    /// Open the zip file that is stored at `key` in `store`.
     #[new]
-    #[pyo3(signature = (store, key, path = None))]
-    fn new(store: PySyncStorage, key: PyStoreKey, path: Option<PathBuf>) -> ZarristaResult<Self> {
-        let zip_store = if let Some(path) = path {
-            ZipStorageAdapter::new_with_path(Arc::new(store), key.into(), path)?
-        } else {
-            ZipStorageAdapter::new(Arc::new(store), key.into())?
-        };
-        Ok(Self(Arc::new(zip_store)))
+    #[pyo3(
+        signature = (store, key, path = None),
+        text_signature = "(store, key, path=None)"
+    )]
+    fn new(
+        py: Python,
+        store: PySyncStorage,
+        key: PyStoreKey,
+        path: Option<PathBuf>,
+    ) -> ZarristaResult<Self> {
+        let key = key.into_inner();
+        let adapter = crate::py::detach(py, || {
+            if let Some(path) = path {
+                ZipStorageAdapter::new_with_path(store.inner(), key.clone(), path)
+            } else {
+                ZipStorageAdapter::new(store.inner(), key.clone())
+            }
+        })?;
+        Ok(Self {
+            storage: Arc::new(ReadOnlyStorageAdapter::new(Arc::new(adapter))),
+            key,
+        })
+    }
+
+    /// Open the zip file that is stored at `key` in `store`.
+    ///
+    /// This is an alias for `ZipStore.__init__`
+    #[staticmethod]
+    #[pyo3(
+        signature = (store, key, path = None),
+        text_signature = "(store, key, path=None)"
+    )]
+    fn open(
+        py: Python,
+        store: PySyncStorage,
+        key: PyStoreKey,
+        path: Option<PathBuf>,
+    ) -> ZarristaResult<Self> {
+        Self::new(py, store, key, path)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("ZipStore({})", self.key.as_str())
     }
 }
 

--- a/src/storage/type_wrappers.rs
+++ b/src/storage/type_wrappers.rs
@@ -78,8 +78,6 @@ impl From<StoreKey> for PyStoreKey {
 /// gives an empty store, or store keys that keep a leading `/`. Therefore this
 /// extractor normalizes the value, and `nested`, `nested/`, and `/nested/` all
 /// select the same directory.
-///
-/// This is an entry-name prefix and not a filesystem path, so it extracts via `PyStorePrefix`.
 pub struct PyZipPath(StorePrefix);
 
 impl FromPyObject<'_, '_> for PyZipPath {

--- a/src/storage/type_wrappers.rs
+++ b/src/storage/type_wrappers.rs
@@ -14,6 +14,12 @@ use zarrs::storage::StoreKey;
 /// See <https://zarr-specs.readthedocs.io/en/latest/v3/core/index.html#abstract-store-interface>.
 pub struct PyStoreKey(StoreKey);
 
+impl PyStoreKey {
+    pub fn into_inner(self) -> StoreKey {
+        self.0
+    }
+}
+
 impl FromPyObject<'_, '_> for PyStoreKey {
     type Error = PyErr;
 

--- a/src/storage/type_wrappers.rs
+++ b/src/storage/type_wrappers.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyString;
 use zarrs::storage::{StoreKey, StorePrefix};
 
@@ -69,30 +70,6 @@ impl From<StoreKey> for PyStoreKey {
     }
 }
 
-pub struct PyStorePrefix(StorePrefix);
-
-impl FromPyObject<'_, '_> for PyStorePrefix {
-    type Error = PyErr;
-
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
-        StorePrefix::new(obj.extract::<String>()?)
-            .map(PyStorePrefix)
-            .map_err(|e| PyValueError::new_err(e.to_string()))
-    }
-}
-
-impl From<PyStorePrefix> for StorePrefix {
-    fn from(py_prefix: PyStorePrefix) -> Self {
-        py_prefix.0
-    }
-}
-
-impl From<StorePrefix> for PyStorePrefix {
-    fn from(prefix: StorePrefix) -> Self {
-        Self(prefix)
-    }
-}
-
 /// The directory inside a zip file that a zip store uses as its root.
 ///
 /// The zip storage adapter removes this value from the start of each zip entry
@@ -103,19 +80,26 @@ impl From<StorePrefix> for PyStorePrefix {
 /// select the same directory.
 ///
 /// This is an entry-name prefix and not a filesystem path, so it extracts via `PyStorePrefix`.
-pub struct PyZipPath(String);
+pub struct PyZipPath(StorePrefix);
 
 impl FromPyObject<'_, '_> for PyZipPath {
     type Error = PyErr;
 
     fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
-        let store_prefix = obj.extract::<PyStorePrefix>()?;
-        Ok(Self(store_prefix.0.to_string()))
+        let path = obj.extract::<PyBackedStr>()?;
+        let mut normalized = path.trim_start_matches('/').to_string();
+        if !normalized.is_empty() && !normalized.ends_with('/') {
+            normalized.push('/');
+        }
+        // Normalization satisfies `StorePrefix`'s invariant, so this cannot fail.
+        let prefix =
+            StorePrefix::new(normalized).map_err(|e| PyValueError::new_err(e.to_string()))?;
+        Ok(Self(prefix))
     }
 }
 
 impl From<PyZipPath> for PathBuf {
     fn from(path: PyZipPath) -> PathBuf {
-        PathBuf::from(path.0)
+        PathBuf::from(path.0.as_str())
     }
 }

--- a/src/storage/type_wrappers.rs
+++ b/src/storage/type_wrappers.rs
@@ -3,6 +3,7 @@
 //! These wrappers are **not** standalone Python classes; they only define serde
 
 use std::convert::Infallible;
+use std::path::PathBuf;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -65,5 +66,23 @@ impl From<PyStoreKey> for StoreKey {
 impl From<StoreKey> for PyStoreKey {
     fn from(key: StoreKey) -> Self {
         Self(key)
+    }
+}
+
+/// The directory inside a zip file that a zip store uses as its root.
+pub struct PyZipPath(PathBuf);
+
+impl FromPyObject<'_, '_> for PyZipPath {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
+        let path = obj.extract::<PathBuf>()?;
+        Ok(Self(path))
+    }
+}
+
+impl From<PyZipPath> for PathBuf {
+    fn from(path: PyZipPath) -> PathBuf {
+        path.0
     }
 }

--- a/src/storage/type_wrappers.rs
+++ b/src/storage/type_wrappers.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyString;
-use zarrs::storage::StoreKey;
+use zarrs::storage::{StoreKey, StorePrefix};
 
 /// A Zarr abstract store key.
 ///
@@ -69,20 +69,53 @@ impl From<StoreKey> for PyStoreKey {
     }
 }
 
+pub struct PyStorePrefix(StorePrefix);
+
+impl FromPyObject<'_, '_> for PyStorePrefix {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
+        StorePrefix::new(obj.extract::<String>()?)
+            .map(PyStorePrefix)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+}
+
+impl From<PyStorePrefix> for StorePrefix {
+    fn from(py_prefix: PyStorePrefix) -> Self {
+        py_prefix.0
+    }
+}
+
+impl From<StorePrefix> for PyStorePrefix {
+    fn from(prefix: StorePrefix) -> Self {
+        Self(prefix)
+    }
+}
+
 /// The directory inside a zip file that a zip store uses as its root.
-pub struct PyZipPath(PathBuf);
+///
+/// The zip storage adapter removes this value from the start of each zip entry
+/// name. Entry names always use `/` and never start with `/`, so the value must
+/// end with `/` and must not start with `/`. A value that breaks either rule
+/// gives an empty store, or store keys that keep a leading `/`. Therefore this
+/// extractor normalizes the value, and `nested`, `nested/`, and `/nested/` all
+/// select the same directory.
+///
+/// This is an entry-name prefix and not a filesystem path, so it extracts via `PyStorePrefix`.
+pub struct PyZipPath(String);
 
 impl FromPyObject<'_, '_> for PyZipPath {
     type Error = PyErr;
 
     fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
-        let path = obj.extract::<PathBuf>()?;
-        Ok(Self(path))
+        let store_prefix = obj.extract::<PyStorePrefix>()?;
+        Ok(Self(store_prefix.0.to_string()))
     }
 }
 
 impl From<PyZipPath> for PathBuf {
     fn from(path: PyZipPath) -> PathBuf {
-        path.0
+        PathBuf::from(path.0)
     }
 }

--- a/tests/test_store_input.py
+++ b/tests/test_store_input.py
@@ -32,7 +32,7 @@ def test_filesystem_store_opens_and_reads(array_path: Path):
 
 
 def test_open_rejects_non_store(array_path: Path):
-    with pytest.raises(TypeError, match="FilesystemStore or MemoryStore"):
+    with pytest.raises(TypeError, match="FilesystemStore, MemoryStore, or ZipStore"):
         Array.open(object())
-    with pytest.raises(TypeError, match="FilesystemStore or MemoryStore"):
+    with pytest.raises(TypeError, match="FilesystemStore, MemoryStore, or ZipStore"):
         Group.open(object())

--- a/tests/test_zip_store.py
+++ b/tests/test_zip_store.py
@@ -115,13 +115,13 @@ def test_invalid_key_is_rejected(zipped: Path):
 
 
 async def test_async_reads_through_zip(zipped: Path):
-    store = await AsyncZipStore.open(LocalStore(str(zipped)), "a.zip")
+    store = await AsyncZipStore.open_async(LocalStore(str(zipped)), "a.zip")
     array = await AsyncArray.open_async(store)
     np.testing.assert_array_equal((await array[:]).to_numpy(), EXPECTED)
 
 
 async def test_async_writes_are_rejected(zipped: Path):
-    store = await AsyncZipStore.open(LocalStore(str(zipped)), "a.zip")
+    store = await AsyncZipStore.open_async(LocalStore(str(zipped)), "a.zip")
     array = await AsyncArray.open_async(store)
     with pytest.raises(StorageError, match="read only store"):
         await array.store_metadata()

--- a/tests/test_zip_store.py
+++ b/tests/test_zip_store.py
@@ -1,0 +1,127 @@
+"""Reading a Zarr store held inside a zip file.
+
+A tiny int32 array is written with zarr-python, packed into a zip file, and then
+read back through `ZipStore`. The store is read-only: every write must fail.
+"""
+
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+from obstore.store import LocalStore
+
+from zarrista import Array, AsyncArray
+from zarrista.exceptions import StorageError
+from zarrista.store import AsyncZipStore, FilesystemStore, ZipStore
+
+EXPECTED = np.arange(4, dtype="int32")
+
+
+def _zip_zarr(
+    tmp_path: Path,
+    name: str,
+    compression: int = zipfile.ZIP_STORED,
+    prefix: str = "",
+) -> Path:
+    """Write a tiny array and pack it into `name`; returns the containing dir."""
+    zarr_dir = tmp_path / "src" / "a.zarr"
+    z = zarr.create_array(store=str(zarr_dir), shape=(4,), chunks=(2,), dtype="int32")
+    z[:] = EXPECTED
+    with zipfile.ZipFile(tmp_path / name, "w", compression) as zf:
+        for entry in sorted(zarr_dir.rglob("*")):
+            if entry.is_file():
+                zf.write(entry, prefix + str(entry.relative_to(zarr_dir)))
+    return tmp_path
+
+
+@pytest.fixture
+def zipped(tmp_path: Path) -> Path:
+    """A stored (uncompressed) zip of a Zarr array; returns the containing dir."""
+    return _zip_zarr(tmp_path, "a.zip")
+
+
+@pytest.mark.parametrize(
+    "compression",
+    [zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED],
+    ids=["stored", "deflated"],
+)
+def test_reads_through_zip(tmp_path: Path, compression: int):
+    root = _zip_zarr(tmp_path, "a.zip", compression)
+    array = Array.open(ZipStore(FilesystemStore(root), "a.zip"))
+    np.testing.assert_array_equal(array[:].to_numpy(), EXPECTED)
+
+
+def test_open_matches_constructor(zipped: Path):
+    store = ZipStore.open(FilesystemStore(zipped), "a.zip")
+    np.testing.assert_array_equal(Array.open(store)[:].to_numpy(), EXPECTED)
+
+
+def test_repr(zipped: Path):
+    assert repr(ZipStore(FilesystemStore(zipped), "a.zip")) == "ZipStore(a.zip)"
+
+
+def test_array_store_round_trips(zipped: Path):
+    store = ZipStore(FilesystemStore(zipped), "a.zip")
+    assert isinstance(Array.open(store).store, ZipStore)
+
+
+def test_writes_are_rejected(zipped: Path):
+    array = Array.open(ZipStore(FilesystemStore(zipped), "a.zip"))
+    with pytest.raises(StorageError, match="read only store"):
+        array.store_metadata()
+
+
+@pytest.mark.parametrize("path", ["nested/", "nested", "/nested/", "//nested"])
+def test_path_selects_a_directory_in_the_zip(tmp_path: Path, path: str):
+    """Leading and trailing slashes are normalized, so every spelling agrees."""
+    root = _zip_zarr(tmp_path, "a.zip", prefix="nested/")
+    store = ZipStore(FilesystemStore(root), "a.zip", path=path)
+    np.testing.assert_array_equal(Array.open(store)[:].to_numpy(), EXPECTED)
+
+
+def test_path_is_keyword_only(zipped: Path):
+    with pytest.raises(TypeError):
+        ZipStore(FilesystemStore(zipped), "a.zip", "nested/")
+
+
+def test_zip_inside_a_zip(zipped: Path):
+    with zipfile.ZipFile(zipped / "outer.zip", "w") as zf:
+        zf.write(zipped / "a.zip", "a.zip")
+
+    outer = ZipStore(FilesystemStore(zipped), "outer.zip")
+    inner = ZipStore(outer, "a.zip")
+    np.testing.assert_array_equal(Array.open(inner)[:].to_numpy(), EXPECTED)
+
+
+def test_missing_key_is_rejected(zipped: Path):
+    with pytest.raises(StorageError):
+        ZipStore(FilesystemStore(zipped), "absent.zip")
+
+
+def test_non_zip_value_is_rejected(tmp_path: Path):
+    (tmp_path / "a.zip").write_bytes(b"not a zip file")
+    with pytest.raises(StorageError):
+        ZipStore(FilesystemStore(tmp_path), "a.zip")
+
+
+def test_invalid_key_is_rejected(zipped: Path):
+    with pytest.raises(ValueError, match="invalid store key"):
+        ZipStore(FilesystemStore(zipped), "/leading-slash")
+
+
+# --- async --------------------------------------------------------------------
+
+
+async def test_async_reads_through_zip(zipped: Path):
+    store = await AsyncZipStore.open(LocalStore(str(zipped)), "a.zip")
+    array = await AsyncArray.open_async(store)
+    np.testing.assert_array_equal((await array[:]).to_numpy(), EXPECTED)
+
+
+async def test_async_writes_are_rejected(zipped: Path):
+    store = await AsyncZipStore.open(LocalStore(str(zipped)), "a.zip")
+    array = await AsyncArray.open_async(store)
+    with pytest.raises(StorageError, match="read only store"):
+        await array.store_metadata()


### PR DESCRIPTION
### Change list

- Adds `ZipStore` and `AsyncZipStore`, which wrap other sync/async stores in order to read a zipped-zarr
- These are read-only stores
- Added `SyncStore` type hint as a union over `FilesystemStore | MemoryStore | ZipStore`