### PR TITLE
refactor!: Rename the `store` accessor to `storage`

### DIFF
--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -332,8 +332,8 @@ class Array:
             An empty cache for this array.
         """
     @property
-    def store(self) -> SyncStore:
-        """Retrieve the store backing this array."""
+    def storage(self) -> SyncStore:
+        """The store that backs this array."""
     def store_array_subset(
         self,
         selection: Selection,
@@ -976,8 +976,8 @@ class AsyncArray:
             An empty cache for this array.
         """
     @property
-    def store(self) -> AsyncStore:
-        """Retrieve the store backing this array."""
+    def storage(self) -> AsyncStore:
+        """The store that backs this array."""
     async def store_array_subset(
         self,
         selection: Selection,

--- a/python/zarrista/_group.pyi
+++ b/python/zarrista/_group.pyi
@@ -108,8 +108,8 @@ class Group:
         This overwrites any metadata that exists at the group's path.
         """
     @property
-    def store(self) -> SyncStore:
-        """Retrieve the store backing this group."""
+    def storage(self) -> SyncStore:
+        """The store that backs this group."""
     def __getitem__(self, name: str) -> Array | Group:
         """Open a direct child array or group by name.
 
@@ -225,5 +225,5 @@ class AsyncGroup:
             KeyError: If the group has no direct child with that name.
         """
     @property
-    def store(self) -> AsyncStore:
-        """Retrieve the store backing this group."""
+    def storage(self) -> AsyncStore:
+        """The store that backs this group."""

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -318,7 +318,7 @@ impl PyAsyncArray {
     }
 
     #[getter]
-    fn store(&self) -> PyAsyncStorage {
+    fn storage(&self) -> PyAsyncStorage {
         self.store.clone()
     }
 

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -259,7 +259,7 @@ impl PyArray {
     }
 
     #[getter]
-    fn store(&self) -> PySyncStorage {
+    fn storage(&self) -> PySyncStorage {
         self.store.clone()
     }
 

--- a/src/group/async.rs
+++ b/src/group/async.rs
@@ -218,7 +218,7 @@ impl PyAsyncGroup {
     }
 
     #[getter]
-    fn store(&self) -> PyAsyncStorage {
+    fn storage(&self) -> PyAsyncStorage {
         self.store.clone()
     }
 

--- a/src/group/sync.rs
+++ b/src/group/sync.rs
@@ -34,7 +34,9 @@ impl PyGroup {
         Self { inner, store }
     }
 
-    fn storage(&self) -> Arc<dyn ReadableWritableListableStorageTraits> {
+    /// The `zarrs` storage behind the group, as opposed to the Python store wrapper
+    /// that the `storage` getter returns.
+    fn inner_storage(&self) -> Arc<dyn ReadableWritableListableStorageTraits> {
         self.inner.storage()
     }
 }
@@ -94,7 +96,7 @@ impl PyGroup {
                 .traverse()?
                 .into_iter()
                 .map(|(path, metadata)| {
-                    let storage = self.storage();
+                    let storage = self.inner_storage();
                     match metadata {
                         NodeMetadata::Array(array_metadata) => {
                             let array =
@@ -181,7 +183,7 @@ impl PyGroup {
     }
 
     #[getter]
-    fn store(&self) -> PySyncStorage {
+    fn storage(&self) -> PySyncStorage {
         self.store.clone()
     }
 

--- a/tests/test_zip_store.py
+++ b/tests/test_zip_store.py
@@ -62,9 +62,9 @@ def test_repr(zipped: Path):
     assert repr(ZipStore(FilesystemStore(zipped), "a.zip")) == "ZipStore(a.zip)"
 
 
-def test_array_store_round_trips(zipped: Path):
+def test_array_storage_round_trips(zipped: Path):
     store = ZipStore(FilesystemStore(zipped), "a.zip")
-    assert isinstance(Array.open(store).store, ZipStore)
+    assert isinstance(Array.open(store).storage, ZipStore)
 
 
 def test_writes_are_rejected(zipped: Path):


### PR DESCRIPTION
I'm doing a naming review in advance of 0.1.

One thing that came up is that we had both:

- `Array.store`: attribute to access the store object that was passed in to `Array.open`
- `Array.store_metadata`: **method** to persist metadata to the store.

Those next to each other makes it look like `store_metadata` is a _noun_ of something that describes the store, but it's actually a verb.

I think it's clearer to rename `store` to `storage`.

Below written by Claude

----

`Array.store` sat directly beside `Array.store_metadata()`, so `store_metadata` read as a noun phrase — "the store's metadata" — rather than the verb it is. Same for `Group.store` next to `Group.store_metadata()` and `Group.metadata`.

The collision was an artifact of combining two conventions:

| | noun | write verbs | collision? |
|---|---|---|---|
| zarrs | `storage()` | `store_*` | no |
| zarr-python | `store` | none | no |
| zarrista (before) | `store` | `store_*` | **yes** |

Neither parent has the problem on its own — zarrista took the noun from one and the verbs from the other.

Renaming the accessor restores zarrs' pairing and makes every `store_*` method read unambiguously as a verb. **Inputs keep the name `store`**, which is what obstore, async-tiff, and zarr-python use at the call site:

```py
array = Array.open(store=FilesystemStore("data"))   # input: store
array.storage                                       # attribute: storage
```

The rule, for future classes: *inputs that accept a store are named `store`; the attribute that holds one is `storage`.*

## Changes

- `storage` getter on `Array`, `AsyncArray`, `Group`, `AsyncGroup`
- Property docstrings become noun phrases, per the project convention for non-function items
- The private `PyGroup::storage` helper becomes `inner_storage` — it returns the zarrs storage, not the Python store wrapper, and the two would otherwise collide

## Breaking change

`array.store` / `group.store` → `array.storage` / `group.storage`. Landing before 0.1.

## Verification

`300 passed, 1 xfailed`; clippy, rustfmt, and ruff all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)