### PR TITLE
refactor!: Rename `subchunk_cache` to `shard_cache`

### DIFF
--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -252,7 +252,7 @@ class Array:
         self,
         subchunk_indices: list[int],
         *,
-        subchunk_cache: ShardCache | None = None,
+        shard_cache: ShardCache | None = None,
         **codec_options: Unpack[CodecOptions],
     ) -> DecodedArray:
         """Read and decode a single subchunk (inner chunk) of a sharded array.
@@ -263,12 +263,12 @@ class Array:
         whole shard.
 
         To read the subchunk, the method first reads the index of the shard that
-        contains it. Use the `subchunk_cache` parameter to cache the shard index.
+        contains it. Use the `shard_cache` parameter to cache the shard index.
 
         Args:
             subchunk_indices: The position of the subchunk in the subchunk grid.
-            subchunk_cache: A cache of shard indexes, created by
-                [`subchunk_cache`][zarrista.Array.subchunk_cache]. The cache must
+            shard_cache: A cache of shard indexes, created by
+                [`shard_cache`][zarrista.Array.shard_cache]. The cache must
                 come from this array. If this is `None`, the method uses a new
                 cache for this call only.
             **codec_options: The codec options, as
@@ -284,7 +284,7 @@ class Array:
         self,
         subchunk_indices: list[int],
         *,
-        subchunk_cache: ShardCache | None = None,
+        shard_cache: ShardCache | None = None,
     ) -> EncodedChunk | None:
         """Read the raw, still-encoded bytes of a subchunk of a sharded array.
 
@@ -301,12 +301,12 @@ class Array:
         the shard holds the bytes of one subchunk.
 
         To read the subchunk, the method first reads the index of the shard that
-        contains it. Use the `subchunk_cache` parameter to cache the shard index.
+        contains it. Use the `shard_cache` parameter to cache the shard index.
 
         Args:
             subchunk_indices: The position of the subchunk in the subchunk grid.
-            subchunk_cache: A cache of shard indexes, created by
-                [`subchunk_cache`][zarrista.Array.subchunk_cache]. The cache must
+            shard_cache: A cache of shard indexes, created by
+                [`shard_cache`][zarrista.Array.shard_cache]. The cache must
                 come from this array. If this is `None`, the method uses a new
                 cache for this call only.
 
@@ -317,7 +317,7 @@ class Array:
         Raises:
             ArrayError: If the array is not exclusively sharded.
         """
-    def subchunk_cache(self) -> ShardCache:
+    def shard_cache(self) -> ShardCache:
         """Create an empty cache of the shard indexes of this array.
 
         Pass the cache to [`retrieve_subchunk`][zarrista.Array.retrieve_subchunk]
@@ -894,7 +894,7 @@ class AsyncArray:
         self,
         subchunk_indices: list[int],
         *,
-        subchunk_cache: AsyncShardCache | None = None,
+        shard_cache: AsyncShardCache | None = None,
         **codec_options: Unpack[CodecOptions],
     ) -> DecodedArray:
         """Read and decode a single subchunk (inner chunk) of a sharded array.
@@ -905,12 +905,12 @@ class AsyncArray:
         whole shard.
 
         To read the subchunk, the method first reads the index of the shard that
-        contains it. Use the `subchunk_cache` parameter to cache the shard index.
+        contains it. Use the `shard_cache` parameter to cache the shard index.
 
         Args:
             subchunk_indices: The position of the subchunk in the subchunk grid.
-            subchunk_cache: A cache of shard indexes, created by
-                [`subchunk_cache`][zarrista.AsyncArray.subchunk_cache]. The cache
+            shard_cache: A cache of shard indexes, created by
+                [`shard_cache`][zarrista.AsyncArray.shard_cache]. The cache
                 must come from this array. If this is `None`, the method uses a
                 new cache for this call only.
             **codec_options: The codec options, as
@@ -926,7 +926,7 @@ class AsyncArray:
         self,
         subchunk_indices: list[int],
         *,
-        subchunk_cache: AsyncShardCache | None = None,
+        shard_cache: AsyncShardCache | None = None,
     ) -> EncodedChunk | None:
         """Read the raw, still-encoded bytes of a subchunk of a sharded array.
 
@@ -943,12 +943,12 @@ class AsyncArray:
         the shard holds the bytes of one subchunk.
 
         To read the subchunk, the method first reads the index of the shard that
-        contains it. Use the `subchunk_cache` parameter to cache the shard index.
+        contains it. Use the `shard_cache` parameter to cache the shard index.
 
         Args:
             subchunk_indices: The position of the subchunk in the subchunk grid.
-            subchunk_cache: A cache of shard indexes, created by
-                [`subchunk_cache`][zarrista.AsyncArray.subchunk_cache]. The cache
+            shard_cache: A cache of shard indexes, created by
+                [`shard_cache`][zarrista.AsyncArray.shard_cache]. The cache
                 must come from this array. If this is `None`, the method uses a
                 new cache for this call only.
 
@@ -959,7 +959,7 @@ class AsyncArray:
         Raises:
             ArrayError: If the array is not exclusively sharded.
         """
-    def subchunk_cache(self) -> AsyncShardCache:
+    def shard_cache(self) -> AsyncShardCache:
         """Create an empty cache of the shard indexes of this array.
 
         This method is not a coroutine. It does not read from the store.

--- a/python/zarrista/_shard_cache.pyi
+++ b/python/zarrista/_shard_cache.pyi
@@ -15,7 +15,7 @@ class ShardCache:
     Each entry holds two 64-bit integers for every subchunk in the shard. A
     shard of 1024 subchunks therefore costs about 16 KiB.
 
-    Use [`Array.subchunk_cache`][zarrista.Array.subchunk_cache] to create a
+    Use [`Array.shard_cache`][zarrista.Array.shard_cache] to create a
     cache. A cache belongs to the array that created it, because it stores
     byte offsets into that array's shards. Do not use a cache with a different
     array. zarrista cannot detect this, and the read returns incorrect data.
@@ -34,9 +34,9 @@ class ShardCache:
         Read every subchunk of a shard, and read the shard index only once:
 
         ```py
-        cache = arr.subchunk_cache()
+        cache = arr.shard_cache()
         for i in range(arr.subchunk_grid_shape[0]):
-            sub = arr.retrieve_subchunk([i, 0], subchunk_cache=cache)
+            sub = arr.retrieve_subchunk([i, 0], shard_cache=cache)
         ```
     """
 
@@ -67,7 +67,7 @@ class AsyncShardCache:
     [`ShardCache`][zarrista.ShardCache]. The methods are coroutines, because the
     cache uses an asynchronous lock.
 
-    Use [`AsyncArray.subchunk_cache`][zarrista.AsyncArray.subchunk_cache] to
+    Use [`AsyncArray.shard_cache`][zarrista.AsyncArray.shard_cache] to
     create a cache. Read
     [`ShardCache`][zarrista.ShardCache] for what the cache holds and for the
     rules that apply to it.
@@ -76,9 +76,9 @@ class AsyncShardCache:
         Read every subchunk of a shard, and read the shard index only once:
 
         ```py
-        cache = arr.subchunk_cache()
+        cache = arr.shard_cache()
         for i in range(arr.subchunk_grid_shape[0]):
-            sub = await arr.retrieve_subchunk([i, 0], subchunk_cache=cache)
+            sub = await arr.retrieve_subchunk([i, 0], shard_cache=cache)
         ```
     """
 

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -249,21 +249,19 @@ impl PyAsyncArray {
         })
     }
 
-    #[pyo3(signature = (subchunk_indices, *, subchunk_cache = None))]
+    #[pyo3(signature = (subchunk_indices, *, shard_cache = None))]
     fn retrieve_encoded_subchunk<'py>(
         &self,
         py: Python<'py>,
         subchunk_indices: PyChunkIndices,
-        subchunk_cache: Option<&PyAsyncShardCache>,
+        shard_cache: Option<&PyAsyncShardCache>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let subchunk_cache = subchunk_cache
-            .cloned()
-            .unwrap_or_else(|| self.subchunk_cache());
+        let shard_cache = shard_cache.cloned().unwrap_or_else(|| self.shard_cache());
 
         let inner = self.inner.clone();
         future_into_py(py, async move {
             let Some(encoded) = inner
-                .async_retrieve_encoded_subchunk(subchunk_cache.as_ref(), &subchunk_indices)
+                .async_retrieve_encoded_subchunk(shard_cache.as_ref(), &subchunk_indices)
                 .await
                 .map_err(ZarristaError::from)?
             else {
@@ -288,17 +286,15 @@ impl PyAsyncArray {
         })
     }
 
-    #[pyo3(signature = (subchunk_indices, *, subchunk_cache = None, **codec_options))]
+    #[pyo3(signature = (subchunk_indices, *, shard_cache = None, **codec_options))]
     fn retrieve_subchunk<'py>(
         &self,
         py: Python<'py>,
         subchunk_indices: PyChunkIndices,
-        subchunk_cache: Option<&PyAsyncShardCache>,
+        shard_cache: Option<&PyAsyncShardCache>,
         codec_options: Option<PyCodecOptions>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let subchunk_cache = subchunk_cache
-            .cloned()
-            .unwrap_or_else(|| self.subchunk_cache());
+        let shard_cache = shard_cache.cloned().unwrap_or_else(|| self.shard_cache());
         let codec_options = codec_options
             .map(|opts| opts.into_inner())
             .unwrap_or_default();
@@ -307,7 +303,7 @@ impl PyAsyncArray {
         future_into_py(py, async move {
             let decoded = inner
                 .async_retrieve_subchunk_opt::<DecodedArray>(
-                    subchunk_cache.as_ref(),
+                    shard_cache.as_ref(),
                     &subchunk_indices,
                     &codec_options,
                 )
@@ -440,7 +436,7 @@ impl PyAsyncArray {
     }
 
     /// Create an empty shard index cache for this array.
-    fn subchunk_cache(&self) -> PyAsyncShardCache {
+    fn shard_cache(&self) -> PyAsyncShardCache {
         PyAsyncShardCache::new(self.clone())
     }
 }

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -197,20 +197,18 @@ impl PyArray {
         })
     }
 
-    #[pyo3(signature = (subchunk_indices, *, subchunk_cache = None))]
+    #[pyo3(signature = (subchunk_indices, *, shard_cache = None))]
     fn retrieve_encoded_subchunk(
         &self,
         py: Python,
         subchunk_indices: PyChunkIndices,
-        subchunk_cache: Option<&PyShardCache>,
+        shard_cache: Option<&PyShardCache>,
     ) -> ZarristaResult<Option<PyEncodedChunk>> {
         crate::py::detach(py, move || {
-            let subchunk_cache = subchunk_cache
-                .cloned()
-                .unwrap_or_else(|| self.subchunk_cache());
+            let shard_cache = shard_cache.cloned().unwrap_or_else(|| self.shard_cache());
             let Some(encoded) = self
                 .inner
-                .retrieve_encoded_subchunk(subchunk_cache.as_ref(), &subchunk_indices)?
+                .retrieve_encoded_subchunk(shard_cache.as_ref(), &subchunk_indices)?
             else {
                 return Ok(None);
             };
@@ -234,24 +232,22 @@ impl PyArray {
         })
     }
 
-    #[pyo3(signature = (subchunk_indices, *, subchunk_cache = None, **codec_options))]
+    #[pyo3(signature = (subchunk_indices, *, shard_cache = None, **codec_options))]
     fn retrieve_subchunk(
         &self,
         py: Python,
         subchunk_indices: PyChunkIndices,
-        subchunk_cache: Option<&PyShardCache>,
+        shard_cache: Option<&PyShardCache>,
         codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<DecodedArray> {
         crate::py::detach(py, move || {
-            let subchunk_cache = subchunk_cache
-                .cloned()
-                .unwrap_or_else(|| self.subchunk_cache());
+            let shard_cache = shard_cache.cloned().unwrap_or_else(|| self.shard_cache());
             let codec_options = codec_options
                 .map(|opts| opts.into_inner())
                 .unwrap_or_default();
 
             Ok(self.inner.retrieve_subchunk_opt(
-                subchunk_cache.as_ref(),
+                shard_cache.as_ref(),
                 &subchunk_indices,
                 &codec_options,
             )?)
@@ -353,7 +349,7 @@ impl PyArray {
     }
 
     /// Create an empty shard index cache for this array.
-    fn subchunk_cache(&self) -> PyShardCache {
+    fn shard_cache(&self) -> PyShardCache {
         PyShardCache::new(self.clone())
     }
 }

--- a/tests/array/test_shard_cache.py
+++ b/tests/array/test_shard_cache.py
@@ -2,8 +2,8 @@
 
 To read one subchunk, zarrista first reads the index of the shard that holds it.
 A `ShardCache` keeps that index, so later reads of the same shard do not read it
-again. `Array.subchunk_cache` constructs a cache, and `retrieve_subchunk` and
-`retrieve_encoded_subchunk` accept one through `subchunk_cache`.
+again. `Array.shard_cache` constructs a cache, and `retrieve_subchunk` and
+`retrieve_encoded_subchunk` accept one through `shard_cache`.
 """
 
 import numpy as np
@@ -51,7 +51,7 @@ def _expected(r: int, c: int) -> np.ndarray:
 
 
 def test_a_new_cache_is_empty():
-    cache = _sharded_array().subchunk_cache()
+    cache = _sharded_array().shard_cache()
 
     assert isinstance(cache, ShardCache)
     assert cache.is_empty()
@@ -60,28 +60,28 @@ def test_a_new_cache_is_empty():
 
 def test_the_cache_holds_one_index_for_each_shard():
     arr = _sharded_array()
-    cache = arr.subchunk_cache()
+    cache = arr.shard_cache()
 
-    arr.retrieve_subchunk([0, 0], subchunk_cache=cache)
+    arr.retrieve_subchunk([0, 0], shard_cache=cache)
     assert cache.size() == 1
     assert not cache.is_empty()
 
     # A different subchunk of the same shard reuses the cached shard index.
-    arr.retrieve_subchunk([1, 1], subchunk_cache=cache)
+    arr.retrieve_subchunk([1, 1], shard_cache=cache)
     assert cache.size() == 1
 
     # A subchunk of the other shard adds the index of that shard.
-    arr.retrieve_subchunk([2, 0], subchunk_cache=cache)
+    arr.retrieve_subchunk([2, 0], shard_cache=cache)
     assert cache.size() == 2
 
 
 def test_a_cached_read_returns_the_same_data():
     arr = _sharded_array()
-    cache = arr.subchunk_cache()
+    cache = arr.shard_cache()
 
     for r in range(4):
         for c in range(2):
-            cached = arr.retrieve_subchunk([r, c], subchunk_cache=cache)
+            cached = arr.retrieve_subchunk([r, c], shard_cache=cache)
             np.testing.assert_array_equal(np.asarray(cached), _expected(r, c))
             np.testing.assert_array_equal(
                 np.asarray(cached),
@@ -91,9 +91,9 @@ def test_a_cached_read_returns_the_same_data():
 
 def test_retrieve_encoded_subchunk_accepts_a_cache():
     arr = _sharded_array()
-    cache = arr.subchunk_cache()
+    cache = arr.shard_cache()
 
-    chunk = arr.retrieve_encoded_subchunk([3, 1], subchunk_cache=cache)
+    chunk = arr.retrieve_encoded_subchunk([3, 1], shard_cache=cache)
 
     assert chunk is not None
     assert cache.size() == 1
@@ -102,35 +102,35 @@ def test_retrieve_encoded_subchunk_accepts_a_cache():
 
 def test_clear_empties_the_cache():
     arr = _sharded_array()
-    cache = arr.subchunk_cache()
-    arr.retrieve_subchunk([0, 0], subchunk_cache=cache)
+    cache = arr.shard_cache()
+    arr.retrieve_subchunk([0, 0], shard_cache=cache)
 
     cache.clear()
 
     assert cache.is_empty()
     assert cache.size() == 0
     # The cache stays usable after it is cleared.
-    arr.retrieve_subchunk([0, 0], subchunk_cache=cache)
+    arr.retrieve_subchunk([0, 0], shard_cache=cache)
     assert cache.size() == 1
 
 
 def test_each_array_constructs_its_own_cache():
     arr = _sharded_array()
 
-    assert arr.subchunk_cache() is not arr.subchunk_cache()
+    assert arr.shard_cache() is not arr.shard_cache()
 
 
 def test_repr_names_the_array_that_created_the_cache():
     arr = _sharded_array()
 
-    assert repr(arr.subchunk_cache()) == f"ShardCache(array={arr!r})"
+    assert repr(arr.shard_cache()) == f"ShardCache(array={arr!r})"
 
 
 def test_a_value_that_is_not_a_shard_cache_raises():
     arr = _sharded_array()
 
     with pytest.raises(TypeError, match="ShardCache"):
-        arr.retrieve_subchunk([0, 0], subchunk_cache="not a cache")
+        arr.retrieve_subchunk([0, 0], shard_cache="not a cache")
 
 
 # --- async ---------------------------------------------------------------
@@ -146,7 +146,7 @@ async def _async_sharded_array(tmp_path) -> AsyncArray:
 async def test_async_a_new_cache_is_empty(tmp_path):
     arr = await _async_sharded_array(tmp_path)
 
-    cache = arr.subchunk_cache()
+    cache = arr.shard_cache()
 
     assert isinstance(cache, AsyncShardCache)
     assert await cache.is_empty()
@@ -155,31 +155,31 @@ async def test_async_a_new_cache_is_empty(tmp_path):
 
 async def test_async_the_cache_holds_one_index_for_each_shard(tmp_path):
     arr = await _async_sharded_array(tmp_path)
-    cache = arr.subchunk_cache()
+    cache = arr.shard_cache()
 
-    await arr.retrieve_subchunk([0, 0], subchunk_cache=cache)
+    await arr.retrieve_subchunk([0, 0], shard_cache=cache)
     assert await cache.size() == 1
 
-    await arr.retrieve_subchunk([1, 1], subchunk_cache=cache)
+    await arr.retrieve_subchunk([1, 1], shard_cache=cache)
     assert await cache.size() == 1
 
-    await arr.retrieve_encoded_subchunk([2, 0], subchunk_cache=cache)
+    await arr.retrieve_encoded_subchunk([2, 0], shard_cache=cache)
     assert await cache.size() == 2
 
 
 async def test_async_a_cached_read_returns_the_same_data(tmp_path):
     arr = await _async_sharded_array(tmp_path)
-    cache = arr.subchunk_cache()
+    cache = arr.shard_cache()
 
-    sub = await arr.retrieve_subchunk([3, 1], subchunk_cache=cache)
+    sub = await arr.retrieve_subchunk([3, 1], shard_cache=cache)
 
     np.testing.assert_array_equal(np.asarray(sub), _expected(3, 1))
 
 
 async def test_async_clear_empties_the_cache(tmp_path):
     arr = await _async_sharded_array(tmp_path)
-    cache = arr.subchunk_cache()
-    await arr.retrieve_subchunk([0, 0], subchunk_cache=cache)
+    cache = arr.shard_cache()
+    await arr.retrieve_subchunk([0, 0], shard_cache=cache)
 
     await cache.clear()
 
@@ -189,11 +189,11 @@ async def test_async_clear_empties_the_cache(tmp_path):
 async def test_async_repr_names_the_array_that_created_the_cache(tmp_path):
     arr = await _async_sharded_array(tmp_path)
 
-    assert repr(arr.subchunk_cache()) == f"AsyncShardCache(array={arr!r})"
+    assert repr(arr.shard_cache()) == f"AsyncShardCache(array={arr!r})"
 
 
 async def test_async_a_value_that_is_not_a_shard_cache_raises(tmp_path):
     arr = await _async_sharded_array(tmp_path)
 
     with pytest.raises(TypeError, match="AsyncShardCache"):
-        await arr.retrieve_subchunk([0, 0], subchunk_cache="not a cache")
+        await arr.retrieve_subchunk([0, 0], shard_cache="not a cache")


### PR DESCRIPTION
Follow up to #160 where I'm doing a bit of naming review prior to releasing 0.1.

I still don't _fully_ understand the difference between `subchunk` and `shard`. I think Claude is telling me that a shard is what _contains_ subchunks.

I think this should be a bit cleaner 🤷‍♂️ 

Below written by claude.

Closes https://github.com/developmentseed/zarrista/issues/135

----

The parameter took a `ShardCache`, and its own docstring described it as *"a cache of shard indexes"* — so the name disagreed with both its type and its purpose:

```py
subchunk_cache: ShardCache | None = None
```

## Why `shard` and not `subchunk`

zarrs uses both terms deliberately, for two different concepts:

- **shard** — the *encoding*. Under `sharding_indexed`, one chunk in the store holds several smaller units plus an index. Meaningful only when that codec is present.
- **subchunk** — the *read granularity*. Defined for every array; on an unsharded array it simply is the chunk.

Upstream states the rule in its doc comments — `subchunk_grid` *"returns the normal chunk grid for an unsharded array"*, while `is_sharded` reports whether the codec is `sharding_indexed`.

The test that follows: **does the name still mean something with no sharding codec?** This cache holds shard indexes, and an unsharded array has no shard index, so there is nothing to cache. It belongs on the shard side. Upstream's type is `ArrayShardedReadableExtCache`, which agrees.

## Changes

Six public symbols on `Array` and `AsyncArray`:

```py
array.shard_cache()
array.retrieve_subchunk(indices, shard_cache=cache)
array.retrieve_encoded_subchunk(indices, shard_cache=cache)
```

The docs also stop contradicting themselves — *"Use the `subchunk_cache` parameter to cache the shard index"* becomes *"Use the `shard_cache` parameter to cache the shard index"*.

## Deliberately unchanged

Every other `subchunk` name describes the read unit rather than the encoding, and stays:

`retrieve_subchunk` · `retrieve_encoded_subchunk` · `subchunk_indices` · `subchunk_grid` · `subchunk_grid_shape` · `subchunk_shape` · `effective_subchunk_shape` · `ArrayBuilder.subchunk_shape`

## Breaking change

`subchunk_cache` → `shard_cache`, as a keyword argument and as a method. Landing before 0.1.

## Verification

`300 passed, 1 xfailed`; clippy, rustfmt, and ruff clean. Confirmed against a real sharded array that `shard_cache=` is accepted and `subchunk_cache=` now raises `TypeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)