### PR TITLE
refactor!: Drop the `_async` suffix from methods on async classes

### DIFF
--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -696,7 +696,7 @@ class AsyncArray:
     """A Zarr array backed by an async store."""
 
     @staticmethod
-    async def open_async(store: AsyncStore, path: str = "/") -> AsyncArray:
+    async def open(store: AsyncStore, path: str = "/") -> AsyncArray:
         """Open the array stored at `path` in `store`.
 
         Args:

--- a/python/zarrista/_group.pyi
+++ b/python/zarrista/_group.pyi
@@ -127,7 +127,7 @@ class AsyncGroup:
     """A Zarr group backed by an async store."""
 
     @staticmethod
-    async def open_async(store: AsyncStore, path: str = "/") -> AsyncGroup:
+    async def open(store: AsyncStore, path: str = "/") -> AsyncGroup:
         """Open the group stored at `path` in `store`.
 
         Args:
@@ -212,7 +212,7 @@ class AsyncGroup:
 
         This succeeds if the metadata does not exist.
         """
-    async def open_child_async(self, name: str) -> AsyncArray | AsyncGroup:
+    async def child(self, name: str) -> AsyncArray | AsyncGroup:
         """Open a direct child array or group by name.
 
         Args:

--- a/python/zarrista/_store.pyi
+++ b/python/zarrista/_store.pyi
@@ -126,7 +126,7 @@ class AsyncZipStore:
     """
 
     @staticmethod
-    async def open_async(
+    async def open(
         store: AsyncStore,
         key: str,
         *,

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -98,7 +98,7 @@ impl PyAsyncArray {
         signature = (store, path = PyNodePath::root()),
         text_signature = "(store, path='/')"
     )]
-    fn open_async<'py>(
+    fn open<'py>(
         py: Python<'py>,
         store: PyAsyncStorage,
         path: PyNodePath,

--- a/src/group/async.rs
+++ b/src/group/async.rs
@@ -43,7 +43,7 @@ impl PyAsyncGroup {
         signature = (store, path = PyNodePath::root()),
         text_signature = "(store, path='/')"
     )]
-    fn open_async<'py>(
+    fn open<'py>(
         py: Python<'py>,
         store: PyAsyncStorage,
         path: PyNodePath,
@@ -87,7 +87,7 @@ impl PyAsyncGroup {
     }
 
     /// Open a direct child array or group by name.
-    fn open_child_async<'py>(&self, py: Python<'py>, name: String) -> PyResult<Bound<'py, PyAny>> {
+    fn child<'py>(&self, py: Python<'py>, name: String) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
         let storage = self.store.clone();
         future_into_py(py, async move {

--- a/src/storage/async.rs
+++ b/src/storage/async.rs
@@ -217,7 +217,7 @@ impl PyAsyncZipStore {
         signature = (store, key, *, path = None),
         text_signature = "(store, key, *, path=None)"
     )]
-    fn open_async<'py>(
+    fn open<'py>(
         py: Python<'py>,
         store: PyAsyncStorage,
         key: PyStoreKey,

--- a/tests/array/test_erase.py
+++ b/tests/array/test_erase.py
@@ -197,7 +197,7 @@ async def _async_chunked_array(tmp_path: Path) -> AsyncArray:
         fill_value=0,
     )
     z[:] = FULL
-    return await AsyncArray.open_async(LocalStore(str(path)))
+    return await AsyncArray.open(LocalStore(str(path)))
 
 
 async def _read_all(array: AsyncArray) -> NDArray[np.int32]:

--- a/tests/array/test_read_only.py
+++ b/tests/array/test_read_only.py
@@ -75,7 +75,7 @@ async def _async_writable_array(tmp_path) -> AsyncArray:
     path = tmp_path / "a.zarr"
     z = zarr.create_array(store=str(path), shape=(4, 4), chunks=(4, 4), dtype="int8")
     z[:] = np.arange(16, dtype="int8").reshape(4, 4)
-    return await AsyncArray.open_async(LocalStore(str(path)))
+    return await AsyncArray.open(LocalStore(str(path)))
 
 
 async def test_async_read_only_still_reads(tmp_path):

--- a/tests/array/test_store_metadata.py
+++ b/tests/array/test_store_metadata.py
@@ -70,7 +70,7 @@ async def test_async_store_metadata_makes_array_openable(tmp_path: Path) -> None
     array = AsyncArray.from_metadata(_metadata(), store)
     await array.store_metadata()
 
-    reopened = await AsyncArray.open_async(LocalStore(str(tmp_path)))
+    reopened = await AsyncArray.open(LocalStore(str(tmp_path)))
     assert reopened.shape == [4, 4]
     assert reopened.dtype.name == "int16"
 

--- a/tests/array/test_with_attrs.py
+++ b/tests/array/test_with_attrs.py
@@ -58,4 +58,4 @@ async def test_async_with_attrs(tmp_path) -> None:
 
     assert updated.attrs == {"units": "km"}
     assert array.attrs == {"units": "m", "long_name": "height"}
-    assert (await AsyncArray.open_async(store, "/a")).attrs["units"] == "km"
+    assert (await AsyncArray.open(store, "/a")).attrs["units"] == "km"

--- a/tests/array/test_with_chunk_grid.py
+++ b/tests/array/test_with_chunk_grid.py
@@ -109,5 +109,5 @@ async def test_async_with_chunk_grid(tmp_path: Path) -> None:
     await regridded.store_metadata()
 
     assert array.chunk_grid.metadata == ChunkGrid.regular([4, 4], [2, 2]).metadata
-    reopened = await AsyncArray.open_async(LocalStore(str(tmp_path)), "/a")
+    reopened = await AsyncArray.open(LocalStore(str(tmp_path)), "/a")
     assert reopened.chunk_grid.metadata == ChunkGrid.regular([4, 4], [4, 4]).metadata

--- a/tests/array/test_with_shape.py
+++ b/tests/array/test_with_shape.py
@@ -111,5 +111,5 @@ async def test_async_with_shape_returns_new_array(tmp_path: Path) -> None:
     await resized.store_metadata()
 
     assert array.shape == [4, 4]
-    reopened = await AsyncArray.open_async(LocalStore(str(tmp_path)), "/a")
+    reopened = await AsyncArray.open(LocalStore(str(tmp_path)), "/a")
     assert reopened.shape == [8, 8]

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -107,7 +107,7 @@ def test_store_and_erase_metadata(hierarchy: Path):
 
 
 async def test_async_traverse(hierarchy: Path):
-    group = await AsyncGroup.open_async(LocalStore(str(hierarchy)))
+    group = await AsyncGroup.open(LocalStore(str(hierarchy)))
     by_path = {node.path: node for node in await group.traverse()}
     assert sorted(by_path) == ["/a0", "/g1", "/g1/inner"]
     assert isinstance(by_path["/a0"], AsyncArray)
@@ -116,7 +116,7 @@ async def test_async_traverse(hierarchy: Path):
 
 
 async def test_async_child_arrays_and_groups(hierarchy: Path):
-    group = await AsyncGroup.open_async(LocalStore(str(hierarchy)))
+    group = await AsyncGroup.open(LocalStore(str(hierarchy)))
 
     arrays = await group.child_arrays()
     assert [a.path for a in arrays] == ["/a0"]
@@ -128,27 +128,27 @@ async def test_async_child_arrays_and_groups(hierarchy: Path):
 
 
 async def test_async_child_paths(hierarchy: Path):
-    group = await AsyncGroup.open_async(LocalStore(str(hierarchy)))
+    group = await AsyncGroup.open(LocalStore(str(hierarchy)))
     assert sorted(await group.child_paths()) == ["/a0", "/g1"]
     assert await group.child_array_paths() == ["/a0"]
     assert await group.child_group_paths() == ["/g1"]
 
 
 async def test_async_open_child(hierarchy: Path):
-    group = await AsyncGroup.open_async(LocalStore(str(hierarchy)))
+    group = await AsyncGroup.open(LocalStore(str(hierarchy)))
 
-    array = await group.open_child_async("a0")
+    array = await group.child("a0")
     assert isinstance(array, AsyncArray)
     assert array.path == "/a0"
 
-    subgroup = await group.open_child_async("g1")
+    subgroup = await group.child("g1")
     assert isinstance(subgroup, AsyncGroup)
     assert subgroup.path == "/g1"
 
     with pytest.raises(KeyError):
-        await group.open_child_async("missing")
+        await group.child("missing")
 
 
 async def test_async_metadata_is_v3(hierarchy: Path):
-    group = await AsyncGroup.open_async(LocalStore(str(hierarchy)))
+    group = await AsyncGroup.open(LocalStore(str(hierarchy)))
     assert group.metadata["zarr_format"] == 3

--- a/tests/test_icechunk.py
+++ b/tests/test_icechunk.py
@@ -55,7 +55,7 @@ async def test_open_array_from_session(
 ):
     session, data = icechunk_session
 
-    arr = await AsyncArray.open_async(session, "/embeddings")
+    arr = await AsyncArray.open(session, "/embeddings")
     result = (await arr[0:2, :, 5:7]).to_numpy()
 
     np.testing.assert_array_equal(result, data[0:2, :, 5:7])
@@ -67,10 +67,10 @@ async def test_open_group_from_session(
 ):
     session, data = icechunk_session
 
-    group = await AsyncGroup.open_async(session)
+    group = await AsyncGroup.open(session)
     assert await group.array_keys() == ["embeddings"]
 
-    arr = await group.open_child_async("embeddings")
+    arr = await group.child("embeddings")
     result = (await arr[...]).to_numpy()
 
     np.testing.assert_array_equal(result, data)
@@ -78,7 +78,7 @@ async def test_open_group_from_session(
 
 async def test_non_session_object_rejected():
     with pytest.raises(TypeError):
-        await AsyncArray.open_async(object(), "/embeddings")
+        await AsyncArray.open(object(), "/embeddings")
 
 
 @requires_icechunk_2
@@ -95,4 +95,4 @@ async def test_old_icechunk_version_rejected(
     monkeypatch.setattr(icechunk, "__version__", "1.1.21")
 
     with pytest.raises(ValueError, match="requires icechunk >= 2"):
-        await AsyncArray.open_async(session, "/embeddings")
+        await AsyncArray.open(session, "/embeddings")

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -157,7 +157,7 @@ async def test_async_getitem_matches_numpy(int32_array: tuple[Path, NDArray[np.i
     """The async path (obstore + `await arr[...]`) returns the same region."""
     path, data = int32_array
 
-    arr = await AsyncArray.open_async(LocalStore(str(path)))
+    arr = await AsyncArray.open(LocalStore(str(path)))
     result = (await arr[0:2, :, 5:7]).to_numpy()
 
     np.testing.assert_array_equal(result, data[0:2, :, 5:7])

--- a/tests/test_zip_store.py
+++ b/tests/test_zip_store.py
@@ -115,13 +115,13 @@ def test_invalid_key_is_rejected(zipped: Path):
 
 
 async def test_async_reads_through_zip(zipped: Path):
-    store = await AsyncZipStore.open_async(LocalStore(str(zipped)), "a.zip")
-    array = await AsyncArray.open_async(store)
+    store = await AsyncZipStore.open(LocalStore(str(zipped)), "a.zip")
+    array = await AsyncArray.open(store)
     np.testing.assert_array_equal((await array[:]).to_numpy(), EXPECTED)
 
 
 async def test_async_writes_are_rejected(zipped: Path):
-    store = await AsyncZipStore.open_async(LocalStore(str(zipped)), "a.zip")
-    array = await AsyncArray.open_async(store)
+    store = await AsyncZipStore.open(LocalStore(str(zipped)), "a.zip")
+    array = await AsyncArray.open(store)
     with pytest.raises(StorageError, match="read only store"):
         await array.store_metadata()


### PR DESCRIPTION
Following #161 and #160 , I'm doing a naming review for 0.1.

In obstore, every async method ends with `_async`. This is because the _same class_ implements both the sync and async methods. In contrast, here we have _two classes_, one for sync and one for async (perhaps that would've been a better design in obstore too 🤷‍♂️ ). 

Here we have `Array` and `AsyncArray`. Originally I was worried that a user would forget they have an `AsyncArray`, and that `open_async` would help them remember that they need to use `await`.

But I think realistically almost everyone using the async API will be doing it inside of an IDE that will yell at them if they forget an `await`.

So here I think having more concise methods is probably good.

We now have:
```py
array = await AsyncArray.open(...)
```
instead of 

```py
array = await AsyncArray.open_async(...)
```

Closes #41.


Written by Claude:

---


## The rule

The `_async` suffix exists to disambiguate a sync and an async variant that **share one class**. `ArrayBuilder` really does have both `create` and `create_async`; `EncodedChunk` has both `decode` and `decode_async`. Those names must differ.

An `Async*` class has nothing to disambiguate from — the class name already carries the distinction, and Python marks the call site with `await`.

That rule already governed **28 of the 34** awaitable methods. `retrieve_chunk`, `store_chunk`, `traverse`, `child_arrays`, `erase_metadata`, `__getitem__` and the rest of `AsyncArray`/`AsyncGroup` never carried a suffix. Four methods disagreed:

```
AsyncArray.open_async        →  AsyncArray.open
AsyncGroup.open_async        →  AsyncGroup.open
AsyncZipStore.open_async     →  AsyncZipStore.open
AsyncGroup.open_child_async  →  AsyncGroup.child
```

**obstore uses the same rule** — `get`/`get_async`, `put`/`put_async` on one class — which is independent corroboration from a codebase we already align with.

## Why `child` and not `open_child`

Every child accessor on `Group` does IO, so an `open_` prefix separates nothing — applied consistently it would demand `open_child_arrays`, `open_child_groups`, `read_array_keys`.

The class already marks IO **structurally**, with no exceptions:

| | IO? |
|---|---|
| `#[getter]` — `attrs`, `metadata`, `consolidated_metadata`, `path`, `storage` | no |
| method — `open`, `child`, `child_arrays`, `child_paths`, `array_keys`, `traverse`, … | yes |

That's stronger than a name prefix, because you can't forget to apply it. `child` also matches its neighbours `child_arrays` / `child_groups` / `child_paths`.

## Result

`Array` and `AsyncArray` now share **all 45 method names exactly** — previously they differed only in `open` vs `open_async`. `Group`/`AsyncGroup` differ only by `__getitem__`, which the async side has never had.

## Breaking change

Four method renames. Landing before 0.1. Note this reverses the `AsyncZipStore.open` → `open_async` rename from #152, which matched the four outliers rather than the 28-method majority.

## Verification

`300 passed, 1 xfailed`; clippy, rustfmt, and ruff clean. Confirmed at runtime that `open` resolves and `open_async` is gone on all three classes, and that `AsyncGroup.child` matches `Group.child`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)