### PR TITLE
docs: Clarify the chunk selection in `store_chunks`

### DIFF
--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -397,10 +397,15 @@ class Array:
     ) -> None:
         """Encode `data` and write it to the chunks selected by `chunks`.
 
-        `chunks` selects in **chunk-grid** coordinates, not element coordinates,
-        so chunk index 0 covers the whole first chunk. `data` holds the elements
-        that the selected chunks span. For a 4x4 array chunked 2x2, one chunk
-        therefore takes 2x2 elements of `data`.
+        `chunks` selects in **chunk-grid** coordinates, not element coordinates.
+        The selection works like numpy basic indexing, but each index counts
+        chunks. One index therefore gives a position along one dimension. A full
+        chunk position is a tuple that holds one index for each dimension. A
+        selection that gives fewer indices than the array has dimensions selects
+        every chunk along the dimensions that remain.
+
+        `data` holds the elements that the selected chunks span, not the chunks
+        themselves.
 
         The method writes whole chunks, so it never reads a chunk before it
         writes. Use
@@ -426,6 +431,30 @@ class Array:
                 dimensions.
             ArrayError: If the array is read-only, or if the size of `data` does
                 not match the selected chunks.
+
+        Examples:
+            Each example uses an array of shape `(4, 4, 4)` with chunks of shape
+            `(2, 2, 2)`. The chunk grid therefore has shape `(2, 2, 2)`.
+
+            Write one chunk. The tuple gives one position in the chunk grid, and
+            that chunk holds 2x2x2 elements:
+
+            ```py
+            arr.store_chunks((0, 0, 0), np.ones((2, 2, 2), dtype="int32"))
+            ```
+
+            Write every chunk at position 0 along the first dimension. This
+            selects 1x2x2 chunks, which together hold 2x4x4 elements:
+
+            ```py
+            arr.store_chunks(0, np.ones((2, 4, 4), dtype="int32"))
+            ```
+
+            Write every chunk in the array:
+
+            ```py
+            arr.store_chunks(..., np.ones((4, 4, 4), dtype="int32"))
+            ```
         """
     def store_encoded_chunk(
         self,
@@ -1041,10 +1070,15 @@ class AsyncArray:
     ) -> None:
         """Encode `data` and write it to the chunks selected by `chunks`.
 
-        `chunks` selects in **chunk-grid** coordinates, not element coordinates,
-        so chunk index 0 covers the whole first chunk. `data` holds the elements
-        that the selected chunks span. For a 4x4 array chunked 2x2, one chunk
-        therefore takes 2x2 elements of `data`.
+        `chunks` selects in **chunk-grid** coordinates, not element coordinates.
+        The selection works like numpy basic indexing, but each index counts
+        chunks. One index therefore gives a position along one dimension. A full
+        chunk position is a tuple that holds one index for each dimension. A
+        selection that gives fewer indices than the array has dimensions selects
+        every chunk along the dimensions that remain.
+
+        `data` holds the elements that the selected chunks span, not the chunks
+        themselves.
 
         The method writes whole chunks, so it never reads a chunk before it
         writes. Use
@@ -1070,6 +1104,30 @@ class AsyncArray:
                 dimensions.
             ArrayError: If the array is read-only, or if the size of `data` does
                 not match the selected chunks.
+
+        Examples:
+            Each example uses an array of shape `(4, 4, 4)` with chunks of shape
+            `(2, 2, 2)`. The chunk grid therefore has shape `(2, 2, 2)`.
+
+            Write one chunk. The tuple gives one position in the chunk grid, and
+            that chunk holds 2x2x2 elements:
+
+            ```py
+            await arr.store_chunks((0, 0, 0), np.ones((2, 2, 2), dtype="int32"))
+            ```
+
+            Write every chunk at position 0 along the first dimension. This
+            selects 1x2x2 chunks, which together hold 2x4x4 elements:
+
+            ```py
+            await arr.store_chunks(0, np.ones((2, 4, 4), dtype="int32"))
+            ```
+
+            Write every chunk in the array:
+
+            ```py
+            await arr.store_chunks(..., np.ones((4, 4, 4), dtype="int32"))
+            ```
         """
     async def store_encoded_chunk(
         self,

--- a/tests/array/test_store_chunks.py
+++ b/tests/array/test_store_chunks.py
@@ -45,6 +45,25 @@ def test_writes_a_single_chunk_into_its_element_region() -> None:
     np.testing.assert_array_equal(array[:, :].to_numpy(), expected)
 
 
+def test_partial_selection_spans_the_remaining_dimensions() -> None:
+    """A selection shorter than the array's rank selects every chunk after it.
+
+    For a 3D array chunked 2x2x2, `0` selects the 1x2x2 chunks at position 0 of
+    the first dimension. Those span 2x4x4 elements, not the 2x2x2 of one chunk.
+    """
+    array = ArrayBuilder(
+        ChunkGrid.regular([4, 4, 4], [2, 2, 2]),
+        DataType.from_string("int32"),
+        FillValue(b"\x00\x00\x00\x00"),
+    ).create(MemoryStore(), "/a")
+
+    array.store_chunks(0, np.ones((2, 4, 4), dtype="int32"))
+
+    expected = np.zeros((4, 4, 4), dtype="int32")
+    expected[0:2] = 1
+    np.testing.assert_array_equal(array[:, :, :].to_numpy(), expected)
+
+
 def test_data_shaped_like_the_chunk_grid_raises() -> None:
     """The destination shape is in elements, so 2x2 chunks want 4x4 elements."""
     array = _array()


### PR DESCRIPTION
Closes #142.

Written by Claude

--- 

## The problem

The docstring said:

> `chunks` selects in **chunk-grid** coordinates, not element coordinates, so **chunk index 0 covers the whole first chunk**.

That is only true for a 1D array. @d-v-b asked on #141 whether "index 0" meant a position in the chunk grid or a literal scalar, and asked for an explicit invocation.

I verified the real behaviour against a `(4, 4, 4)` array chunked `(2, 2, 2)`:

| selection | required `data` shape | |
|---|---|---|
| `(0, 0, 0)` | `(2, 2, 2)` | one chunk |
| `0` | `(2, 4, 4)` | **1x2x2 chunks**, not "the first chunk" |
| `(0, 0)` | `(2, 2, 4)` | |
| `...` | `(4, 4, 4)` | every chunk |

So a bare `0` selects a whole slab. The old sentence would have led someone to pass a single chunk's worth of data.

## The fix

The docstring now states that the selection works like numpy basic indexing over the chunk grid, that one index gives a position along one dimension, that a full chunk position is a tuple, and that a shorter selection covers every chunk along the dimensions that remain. Three examples show the single-chunk, partial, and whole-array cases — answering the request for an explicit invocation.

Applied to both `Array` and `AsyncArray`.

## Test

`tests/array/test_store_chunks.py` covered 2D only, and nothing pinned the partial-selection case — which is why the wrong description survived. Added one 3D test mirroring the documented example.

## Verification

`301 passed, 1 xfailed`; ruff check and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)