### PR TITLE
fix: Improve `__repr__` for codec/encoding types

### DIFF
--- a/src/array/chunk_key_encoding.rs
+++ b/src/array/chunk_key_encoding.rs
@@ -28,8 +28,14 @@ impl PyChunkKeyEncoding {
 
 #[pymethods]
 impl PyChunkKeyEncoding {
-    fn __repr__(&self) -> String {
-        format!("ChunkKeyEncoding({:?})", self.0)
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        let metadata = self.0.metadata();
+        crate::repr::named_config_repr(
+            py,
+            "ChunkKeyEncoding",
+            Some(Cow::Borrowed(metadata.name())),
+            metadata.configuration().cloned().map(Into::into),
+        )
     }
 
     // TODO: not sure whether we want constructors as classmethods or as free functions.

--- a/src/array/chunk_key_encoding.rs
+++ b/src/array/chunk_key_encoding.rs
@@ -9,6 +9,7 @@ use zarrs::array::{ChunkKeyEncoding, ChunkKeySeparator};
 
 use crate::error::ZarristaResult;
 use crate::metadata::PyMetadataV3;
+use crate::repr::named_config_repr;
 
 #[derive(Debug, Clone)]
 #[pyclass(module = "zarrista", frozen, name = "ChunkKeyEncoding", from_py_object)]
@@ -30,7 +31,7 @@ impl PyChunkKeyEncoding {
 impl PyChunkKeyEncoding {
     fn __repr__(&self, py: Python) -> PyResult<String> {
         let metadata = self.0.metadata();
-        crate::repr::named_config_repr(
+        named_config_repr(
             py,
             "ChunkKeyEncoding",
             Some(Cow::Borrowed(metadata.name())),

--- a/src/codec/array_to_array.rs
+++ b/src/codec/array_to_array.rs
@@ -13,6 +13,7 @@ use crate::array_bytes::PyArrayBytes;
 use crate::dtype::PyDataType;
 use crate::error::ZarristaResult;
 use crate::metadata::{PyConfiguration, PyMetadataV3};
+use crate::repr::named_config_repr;
 
 #[pyfunction]
 pub fn transpose(order: Vec<usize>) -> ZarristaResult<PyArrayToArrayCodec> {
@@ -50,7 +51,7 @@ impl PyArrayToArrayCodec {
 #[pymethods]
 impl PyArrayToArrayCodec {
     fn __repr__(&self, py: Python) -> PyResult<String> {
-        crate::repr::named_config_repr(py, "ArrayToArrayCodec", self.0.name_v3(), self.config())
+        named_config_repr(py, "ArrayToArrayCodec", self.0.name_v3(), self.config())
     }
 
     /// Build a codec from its Zarr v3 metadata,

--- a/src/codec/array_to_array.rs
+++ b/src/codec/array_to_array.rs
@@ -49,8 +49,8 @@ impl PyArrayToArrayCodec {
 
 #[pymethods]
 impl PyArrayToArrayCodec {
-    fn __repr__(&self) -> String {
-        format!("ArrayToArrayCodec({:?})", self.0)
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        crate::repr::named_config_repr(py, "ArrayToArrayCodec", self.0.name_v3(), self.config())
     }
 
     /// Build a codec from its Zarr v3 metadata,

--- a/src/codec/array_to_bytes/mod.rs
+++ b/src/codec/array_to_bytes/mod.rs
@@ -15,6 +15,7 @@ use zarrs::array::{ArrayToBytesCodecTraits, Codec};
 
 use crate::error::ZarristaResult;
 use crate::metadata::{PyConfiguration, PyMetadataV3};
+use crate::repr::named_config_repr;
 
 #[derive(Debug, Clone)]
 #[pyclass(
@@ -40,7 +41,7 @@ impl PyArrayToBytesCodec {
 #[pymethods]
 impl PyArrayToBytesCodec {
     fn __repr__(&self, py: Python) -> PyResult<String> {
-        crate::repr::named_config_repr(py, "ArrayToBytesCodec", self.0.name_v3(), self.config())
+        named_config_repr(py, "ArrayToBytesCodec", self.0.name_v3(), self.config())
     }
 
     /// Build a codec from its Zarr v3 metadata,

--- a/src/codec/array_to_bytes/mod.rs
+++ b/src/codec/array_to_bytes/mod.rs
@@ -39,8 +39,8 @@ impl PyArrayToBytesCodec {
 
 #[pymethods]
 impl PyArrayToBytesCodec {
-    fn __repr__(&self) -> String {
-        format!("ArrayToBytesCodec({:?})", self.0)
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        crate::repr::named_config_repr(py, "ArrayToBytesCodec", self.0.name_v3(), self.config())
     }
 
     /// Build a codec from its Zarr v3 metadata,

--- a/src/codec/bytes_to_bytes/mod.rs
+++ b/src/codec/bytes_to_bytes/mod.rs
@@ -16,6 +16,7 @@ use zarrs::array::{BytesToBytesCodecTraits, Codec, CodecOptions};
 
 use crate::error::ZarristaResult;
 use crate::metadata::{PyConfiguration, PyMetadataV3};
+use crate::repr::named_config_repr;
 
 #[derive(Debug, Clone)]
 #[pyclass(
@@ -41,7 +42,7 @@ impl PyBytesToBytesCodec {
 #[pymethods]
 impl PyBytesToBytesCodec {
     fn __repr__(&self, py: Python) -> PyResult<String> {
-        crate::repr::named_config_repr(py, "BytesToBytesCodec", self.0.name_v3(), self.config())
+        named_config_repr(py, "BytesToBytesCodec", self.0.name_v3(), self.config())
     }
 
     /// Build a codec from its Zarr v3 metadata,

--- a/src/codec/bytes_to_bytes/mod.rs
+++ b/src/codec/bytes_to_bytes/mod.rs
@@ -40,8 +40,8 @@ impl PyBytesToBytesCodec {
 
 #[pymethods]
 impl PyBytesToBytesCodec {
-    fn __repr__(&self) -> String {
-        format!("BytesToBytesCodec({:?})", self.0)
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        crate::repr::named_config_repr(py, "BytesToBytesCodec", self.0.name_v3(), self.config())
     }
 
     /// Build a codec from its Zarr v3 metadata,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod group;
 mod metadata;
 mod node;
 mod py;
+mod repr;
 mod storage;
 mod thread_pool;
 mod wasm;

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -1,0 +1,42 @@
+//! Helpers for building `__repr__` strings.
+//!
+//! A `__repr__` must never format a zarrs type with `Debug`. That prints the
+//! Rust type name and its struct syntax, such as
+//! ```text
+//! ZstdCodec { compression: 3, checksum: false }
+//! ```
+//! which are implementation details of this crate.
+//!
+//! Build the string from the Zarr v3 name and configuration instead, and render the configuration
+//! through Python so that it uses Python syntax rather than JSON.
+
+use std::borrow::Cow;
+
+use pyo3::prelude::*;
+
+use crate::metadata::PyConfiguration;
+
+/// Build the repr of a type that Zarr v3 describes with a name and a configuration.
+///
+/// The result reads `Class("name", config={...})`. The name is absent for a
+/// type that Zarr v3 does not name, and the configuration is absent when it
+/// holds no entries.
+pub(crate) fn named_config_repr(
+    py: Python,
+    class: &str,
+    name: Option<Cow<'_, str>>,
+    config: Option<PyConfiguration>,
+) -> PyResult<String> {
+    let mut parts = Vec::with_capacity(2);
+    if let Some(name) = name {
+        parts.push(format!("{name:?}"));
+    }
+    if let Some(config) = config {
+        let config = config.into_pyobject(py)?;
+        // An empty configuration adds nothing that the name does not already say.
+        if config.is_truthy()? {
+            parts.push(format!("config={}", config.repr()?));
+        }
+    }
+    Ok(format!("{class}({})", parts.join(", ")))
+}

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -7,18 +7,24 @@
 //! ```
 //! which are implementation details of this crate.
 //!
-//! Build the string from the Zarr v3 name and configuration instead, and render the configuration
-//! through Python so that it uses Python syntax rather than JSON.
+//! Build the string from the Zarr v3 name and configuration instead.
+//!
+//! Every value comes from Python's own `repr`, never from a Rust formatter.
+//! Python then owns the syntax, so a configuration reads `{'level': 3}` rather
+//! than the JSON `{"level":3}`, and a boolean reads `False` rather than `false`.
+//! Rendering one value in Rust and another in Python would also mix quoting
+//! styles inside a single repr.
 
 use std::borrow::Cow;
 
 use pyo3::prelude::*;
+use pyo3::types::PyString;
 
 use crate::metadata::PyConfiguration;
 
 /// Build the repr of a type that Zarr v3 describes with a name and a configuration.
 ///
-/// The result reads `Class("name", config={...})`. The name is absent for a
+/// The result reads `Class('name', config={...})`. The name is absent for a
 /// type that Zarr v3 does not name, and the configuration is absent when it
 /// holds no entries.
 pub(crate) fn named_config_repr(
@@ -29,7 +35,7 @@ pub(crate) fn named_config_repr(
 ) -> PyResult<String> {
     let mut parts = Vec::with_capacity(2);
     if let Some(name) = name {
-        parts.push(format!("{name:?}"));
+        parts.push(PyString::new(py, &name).repr()?.to_string());
     }
     if let Some(config) = config {
         let config = config.into_pyobject(py)?;

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -4,6 +4,9 @@ These types wrap a zarrs struct. Formatting that struct with Rust's `Debug`
 would print its Rust type name and `{ field: value }` syntax, which are
 implementation details of the extension. Each repr is built from the Zarr v3
 name and configuration instead.
+
+Python renders every value, so the quoting and the literals are Python's own:
+strings use `'`, and a boolean reads `False` rather than the JSON `false`.
 """
 
 import re
@@ -20,18 +23,18 @@ RUST_DEBUG_STRUCT = re.compile(r"[A-Z]\w+ \{")
 @pytest.mark.parametrize(
     ("obj", "expected"),
     [
-        (codec.crc32c(), 'BytesToBytesCodec("crc32c")'),
+        (codec.crc32c(), "BytesToBytesCodec('crc32c')"),
         (
             codec.zstd(3, checksum=False),
-            "BytesToBytesCodec(\"zstd\", config={'level': 3, 'checksum': False})",
+            "BytesToBytesCodec('zstd', config={'level': 3, 'checksum': False})",
         ),
         (
             codec.transpose([1, 0]),
-            "ArrayToArrayCodec(\"transpose\", config={'order': [1, 0]})",
+            "ArrayToArrayCodec('transpose', config={'order': [1, 0]})",
         ),
         (
             ChunkKeyEncoding.default("/"),
-            "ChunkKeyEncoding(\"default\", config={'separator': '/'})",
+            "ChunkKeyEncoding('default', config={'separator': '/'})",
         ),
     ],
 )

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,57 @@
+"""`__repr__` shows Zarr v3 names and Python syntax, never Rust internals.
+
+These types wrap a zarrs struct. Formatting that struct with Rust's `Debug`
+would print its Rust type name and `{ field: value }` syntax, which are
+implementation details of the extension. Each repr is built from the Zarr v3
+name and configuration instead.
+"""
+
+import re
+
+import pytest
+
+from zarrista import ChunkKeyEncoding, codec
+
+# `Debug` output looks like `ZstdCodec { compression: 3 }`: a Rust type name in
+# UpperCamelCase, then a brace. Python's dict repr never matches this.
+RUST_DEBUG_STRUCT = re.compile(r"[A-Z]\w+ \{")
+
+
+@pytest.mark.parametrize(
+    ("obj", "expected"),
+    [
+        (codec.crc32c(), 'BytesToBytesCodec("crc32c")'),
+        (
+            codec.zstd(3, checksum=False),
+            "BytesToBytesCodec(\"zstd\", config={'level': 3, 'checksum': False})",
+        ),
+        (
+            codec.transpose([1, 0]),
+            "ArrayToArrayCodec(\"transpose\", config={'order': [1, 0]})",
+        ),
+        (
+            ChunkKeyEncoding.default("/"),
+            "ChunkKeyEncoding(\"default\", config={'separator': '/'})",
+        ),
+    ],
+)
+def test_repr_uses_the_zarr_name_and_python_syntax(obj: object, expected: str) -> None:
+    assert repr(obj) == expected
+
+
+def test_repr_never_shows_rust_struct_syntax() -> None:
+    """A guard for every type whose repr is built from a zarrs struct."""
+    for obj in (
+        codec.crc32c(),
+        codec.zstd(3, checksum=False),
+        codec.gzip(5),
+        codec.blosc("zstd", 5, "noshuffle"),
+        codec.transpose([1, 0]),
+        ChunkKeyEncoding.default("."),
+    ):
+        assert not RUST_DEBUG_STRUCT.search(repr(obj)), repr(obj)
+
+
+def test_empty_configuration_is_omitted() -> None:
+    """`crc32c` takes no options, so a `config=` entry would say nothing."""
+    assert "config=" not in repr(codec.crc32c())


### PR DESCRIPTION
For https://github.com/developmentseed/zarrista/issues/139

Written by Claude:
---

Refs #139. Scoped to the rule that *no repr should ever expose an internal Rust struct* — the rest of #139 (eleven classes with no `__repr__`, plus quoting inconsistencies) is left for follow-up.

## The bug

Four types formatted their zarrs struct with `Debug`, printing Rust type names and `{ field: value }` syntax to Python users:

```
ChunkKeyEncoding(ChunkKeyEncoding(DefaultChunkKeyEncoding { separator: Slash }))
BytesToBytesCodec(ZstdCodec { compression: 3, checksum: false })
ArrayToArrayCodec(TransposeCodec { order: TransposeOrder([1, 0]) })
ArrayToBytesCodec(...)
```

The first also repeats its own class name.

## The fix

Each repr is built from the Zarr v3 name and configuration, which all four types already expose via `name_v3()` / `configuration_v3()`.

**Python renders every value.** The name goes through `PyString::repr` and the configuration through the pythonized dict's `repr`, so nothing maps Rust values onto Python syntax by hand:

```py
ChunkKeyEncoding('default', config={'separator': '/'})
BytesToBytesCodec('zstd', config={'level': 3, 'checksum': False})
BytesToBytesCodec('crc32c')
ArrayToArrayCodec('transpose', config={'order': [1, 0]})
```

That's what keeps `False` and `None` from drifting back to the JSON `false` and `null` — the alternative, serializing the config directly, would have swapped one leak (Rust syntax) for another (JSON syntax). It also means the whole string uses one quoting style; rendering the name in Rust gave `"zstd"` beside `{'level': 3}`.

A configuration with no entries is omitted, since the name already says everything.

The shared helper lives in a new `src/repr.rs`, so the remaining #139 work has somewhere to go.

## Tests

New `tests/test_repr.py` pins the exact output, plus a guard that regex-matches Rust `Debug` struct syntax (`[A-Z]\w+ \{`) across every affected type — a pattern Python's dict repr cannot produce, so it catches regressions rather than only the cases fixed here.

## Not addressed here

- Eleven classes still have no `__repr__` (`ChunkGrid`, `FillValue`, `ArrayBuilder`, `CodecChain`, `EncodedChunk`, `Tensor`, `VariableArray`, `MaskedTensor`, `MaskedVariableArray`, `TensorBuffer`, `ThreadPool`)
- `Array(shape=[4, 4], dtype="DataType(int32 / <i4)")` nests a repr inside quotes
- `FilesystemStore(/data)` and `ZipStore(a.zip)` omit the keyword and quotes that `Group(path="/")` uses

Those last two are where the "Python renders every value" rule would want extending, since they still format through Rust.

## Verification

`307 passed, 1 xfailed`; clippy, rustfmt, and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)