### PR TITLE
feat: Add `__repr__` to the decoded array types

### DIFF
--- a/src/data/tensor.rs
+++ b/src/data/tensor.rs
@@ -13,6 +13,7 @@ use zarrs::array::{ArrayError, DataType, DataTypeSize};
 
 use crate::data::buffer_protocol::PyTensorBuffer;
 use crate::dtype::PyDataType;
+use crate::repr::decoded_array_repr;
 
 /// Fixed-width, dense decoded data.
 ///
@@ -79,6 +80,10 @@ impl PyTensor {
     #[getter]
     fn shape(&self) -> &[u64] {
         &self.shape
+    }
+
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        decoded_array_repr(py, "Tensor", self.shape(), &self.dtype())
     }
 
     #[getter]
@@ -250,6 +255,10 @@ impl PyMaskedTensor {
     #[getter]
     fn shape(&self) -> &[u64] {
         &self.data.shape
+    }
+
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        decoded_array_repr(py, "MaskedTensor", self.shape(), &self.dtype())
     }
 
     #[getter]

--- a/src/data/variable.rs
+++ b/src/data/variable.rs
@@ -14,6 +14,7 @@ use zarrs::array::DataType;
 use zarrs::array::data_type::{BytesDataType, StringDataType};
 
 use crate::dtype::PyDataType;
+use crate::repr::decoded_array_repr;
 
 /// Variable-length data (string/bytes).
 #[pyclass(module = "zarrista", frozen, name = "VariableArray")]
@@ -111,6 +112,10 @@ impl PyVariableArray {
         &self.shape
     }
 
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        decoded_array_repr(py, "VariableArray", self.shape(), &self.dtype())
+    }
+
     #[pyo3(signature = (dtype=None, copy=None))]
     fn __array__<'py>(
         &self,
@@ -191,6 +196,10 @@ impl PyMaskedVariableArray {
     #[getter]
     fn dtype(&self) -> PyDataType {
         self.data_type.clone().into()
+    }
+
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        decoded_array_repr(py, "MaskedVariableArray", self.shape(), &self.dtype())
     }
 }
 

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -46,7 +46,7 @@ impl PyDataType {
     }
 
     #[getter]
-    fn name(&self) -> Option<Cow<'static, str>> {
+    pub(crate) fn name(&self) -> Option<Cow<'static, str>> {
         self.inner.name_v3()
     }
 

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -18,8 +18,9 @@
 use std::borrow::Cow;
 
 use pyo3::prelude::*;
-use pyo3::types::PyString;
+use pyo3::types::{PyList, PyString};
 
+use crate::dtype::PyDataType;
 use crate::metadata::PyConfiguration;
 
 /// Build the repr of a type that Zarr v3 describes with a name and a configuration.
@@ -45,4 +46,19 @@ pub(crate) fn named_config_repr(
         }
     }
     Ok(format!("{class}({})", parts.join(", ")))
+}
+
+/// Build the repr of a decoded array, which reads `Class(shape=[4, 4], dtype='int32')`.
+///
+/// The data type shows its Zarr v3 name. A data type that Zarr v3 does not name
+/// shows `None`, because no shorter description of it exists.
+pub(crate) fn decoded_array_repr(
+    py: Python,
+    class: &str,
+    shape: &[u64],
+    dtype: &PyDataType,
+) -> PyResult<String> {
+    let shape = PyList::new(py, shape)?.repr()?;
+    let dtype = dtype.name().into_pyobject(py)?.repr()?;
+    Ok(format!("{class}(shape={shape}, dtype={dtype})"))
 }

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -10,10 +10,14 @@ strings use `'`, and a boolean reads `False` rather than the JSON `false`.
 """
 
 import re
+from pathlib import Path
 
+import numpy as np
 import pytest
+import zarr
 
-from zarrista import ChunkKeyEncoding, codec
+from zarrista import Array, ChunkKeyEncoding, codec
+from zarrista.store import FilesystemStore
 
 # `Debug` output looks like `ZstdCodec { compression: 3 }`: a Rust type name in
 # UpperCamelCase, then a brace. Python's dict repr never matches this.
@@ -58,3 +62,27 @@ def test_repr_never_shows_rust_struct_syntax() -> None:
 def test_empty_configuration_is_omitted() -> None:
     """`crc32c` takes no options, so a `config=` entry would say nothing."""
     assert "config=" not in repr(codec.crc32c())
+
+
+def test_tensor_repr(tmp_path: Path) -> None:
+    array = zarr.create_array(
+        store=str(tmp_path),
+        shape=(4, 4),
+        chunks=(2, 2),
+        dtype="int32",
+    )
+    array[:] = np.zeros((4, 4), dtype="int32")
+
+    tensor = Array.open(FilesystemStore(tmp_path))[:, :]
+
+    assert repr(tensor) == "Tensor(shape=[4, 4], dtype='int32')"
+
+
+def test_variable_array_repr(tmp_path: Path) -> None:
+    """The data type shows its Zarr v3 name, not the numpy descr."""
+    array = zarr.create_array(store=str(tmp_path), shape=(3,), chunks=(3,), dtype=str)
+    array[:] = np.array(["a", "bb", "ccc"], dtype=object)
+
+    variable = Array.open(FilesystemStore(tmp_path))[:]
+
+    assert repr(variable) == "VariableArray(shape=[3], dtype='string')"


### PR DESCRIPTION
Written by Claude

--- 

Refs #139, following #165.

## Why these four first

`Tensor`, `VariableArray`, `MaskedTensor`, and `MaskedVariableArray` had no `__repr__`, so they showed a memory address:

```
<zarrista.Tensor object at 0x10956edd0>
```

Every read returns one of these four, which makes them the objects a user sees most often at a prompt — the highest-value entry on the remaining #139 list, and all four share a single pattern.

## After

```py
Tensor(shape=[4, 4], dtype='int32')
VariableArray(shape=[3], dtype='string')
```

Two details worth noting:

**The data type shows `name`, not its own repr.** `DataType` reprs as `DataType(int32 / <i4)`, and nesting that is exactly what gives `Array` the awkward `dtype="DataType(int32 / <i4)"` still open on #139. Using `name` keeps it to `'int32'`.

**Python renders both values**, via `PyList::repr` and `PyString::repr`, continuing the rule from #165 that nothing maps a Rust value onto Python syntax by hand. That also means the quoting matches the codec reprs.

`PyDataType::name` became `pub(crate)` so the helper can reach it.

## Tests

`Tensor` and `VariableArray` are pinned exactly. The masked types need a data type carrying a validity mask — the decode path documents those as a skeleton and no test constructs one yet, so they're covered only by sharing `decoded_array_repr`, which keeps the format from diverging. Worth revisiting when nullable dtypes get test coverage.

## Verification

`309 passed, 1 xfailed`; clippy, rustfmt, and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)