### PR TITLE
feat: Consistency pass for `__repr__`

### DIFF
--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -20,6 +20,7 @@ use crate::data::{DecodedArray, PyDataInput};
 use crate::error::{ZarristaError, ZarristaResult};
 use crate::metadata::PyArrayMetadata;
 use crate::node::PyNodePath;
+use crate::repr::array_repr;
 use crate::storage::{AsyncReadOnlyStorageAdapter, PyAsyncStorage};
 
 /// A Zarr array.
@@ -67,12 +68,9 @@ impl PyAsyncArray {
         self.retrieve_array_subset(py, selection)
     }
 
-    fn __repr__(&self) -> String {
-        format!(
-            "AsyncArray(shape={:?}, dtype={:?})",
-            self.inner.shape(),
-            self.dtype().__repr__()
-        )
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        let path = PyNodePath::from(self.inner.path().clone());
+        array_repr(py, "AsyncArray", &path, self.inner.shape(), &self.dtype())
     }
 
     /// Use the provided metadata to open a new array at `path` in `store`.
@@ -465,8 +463,11 @@ impl PyAsyncShardCache {
 
 #[pymethods]
 impl PyAsyncShardCache {
-    fn __repr__(&self) -> String {
-        format!("AsyncShardCache(array={})", self.array.__repr__())
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        Ok(format!(
+            "AsyncShardCache(array={})",
+            self.array.__repr__(py)?
+        ))
     }
 
     /// Remove every shard index from the cache.

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -18,6 +18,7 @@ use crate::data::{DecodedArray, PyDataInput};
 use crate::error::ZarristaResult;
 use crate::metadata::PyArrayMetadata;
 use crate::node::PyNodePath;
+use crate::repr::array_repr;
 use crate::storage::{PySyncStorage, ReadOnlyStorageAdapter};
 
 /// A Zarr array.
@@ -63,12 +64,9 @@ impl PyArray {
         self.retrieve_array_subset(py, selection)
     }
 
-    fn __repr__(&self) -> String {
-        format!(
-            "Array(shape={:?}, dtype={:?})",
-            self.inner.shape(),
-            self.dtype().__repr__()
-        )
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        let path = PyNodePath::from(self.inner.path().clone());
+        array_repr(py, "Array", &path, self.inner.shape(), &self.dtype())
     }
 
     /// Use the provided metadata to open a new array at `path` in `store`.
@@ -375,8 +373,8 @@ impl PyShardCache {
 
 #[pymethods]
 impl PyShardCache {
-    fn __repr__(&self) -> String {
-        format!("ShardCache(array={})", self.array.__repr__())
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        Ok(format!("ShardCache(array={})", self.array.__repr__(py)?))
     }
 
     /// Remove every shard index from the cache.

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -66,8 +66,10 @@ impl PyDataType {
         }
     }
 
-    pub(crate) fn __repr__(&self) -> String {
-        format!("DataType({})", self.inner)
+    pub(crate) fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        // Render the Zarr v3 name
+        let name = self.inner.name_v3().into_pyobject(py)?.repr()?;
+        Ok(format!("DataType({name})"))
     }
 }
 

--- a/src/group/async.rs
+++ b/src/group/async.rs
@@ -234,7 +234,8 @@ impl PyAsyncGroup {
         })
     }
 
-    fn __repr__(&self) -> String {
-        format!("AsyncGroup(path={:?})", self.inner.path().as_str())
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        let path = PyNodePath::from(self.inner.path().clone());
+        Ok(format!("AsyncGroup(path={})", path.repr(py)?))
     }
 }

--- a/src/group/sync.rs
+++ b/src/group/sync.rs
@@ -195,7 +195,8 @@ impl PyGroup {
         })
     }
 
-    fn __repr__(&self) -> String {
-        format!("Group(path={:?})", self.inner.path().as_str())
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        let path = PyNodePath::from(self.inner.path().clone());
+        Ok(format!("Group(path={})", path.repr(py)?))
     }
 }

--- a/src/node/node_path.rs
+++ b/src/node/node_path.rs
@@ -18,6 +18,11 @@ impl PyNodePath {
     pub fn as_str(&self) -> &str {
         self.0.as_str()
     }
+
+    /// The path as Python renders it, for embedding in a `__repr__`.
+    pub(crate) fn repr(&self, py: Python<'_>) -> PyResult<String> {
+        Ok(PyString::new(py, self.as_str()).repr()?.to_string())
+    }
 }
 
 impl FromPyObject<'_, '_> for PyNodePath {

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -22,6 +22,7 @@ use pyo3::types::{PyList, PyString};
 
 use crate::dtype::PyDataType;
 use crate::metadata::PyConfiguration;
+use crate::node::PyNodePath;
 
 /// Build the repr of a type that Zarr v3 describes with a name and a configuration.
 ///
@@ -48,17 +49,39 @@ pub(crate) fn named_config_repr(
     Ok(format!("{class}({})", parts.join(", ")))
 }
 
-/// Build the repr of a decoded array, which reads `Class(shape=[4, 4], dtype='int32')`.
+/// Render `shape=[4, 4], dtype='int32'`, which every array-like repr ends with.
 ///
 /// The data type shows its Zarr v3 name. A data type that Zarr v3 does not name
 /// shows `None`, because no shorter description of it exists.
+fn shape_and_dtype(py: Python, shape: &[u64], dtype: &PyDataType) -> PyResult<String> {
+    let shape = PyList::new(py, shape)?.repr()?;
+    let dtype = dtype.name().into_pyobject(py)?.repr()?;
+    Ok(format!("shape={shape}, dtype={dtype}"))
+}
+
+/// Build the repr of a decoded array, which reads `Class(shape=[4, 4], dtype='int32')`.
 pub(crate) fn decoded_array_repr(
     py: Python,
     class: &str,
     shape: &[u64],
     dtype: &PyDataType,
 ) -> PyResult<String> {
-    let shape = PyList::new(py, shape)?.repr()?;
-    let dtype = dtype.name().into_pyobject(py)?.repr()?;
-    Ok(format!("{class}(shape={shape}, dtype={dtype})"))
+    Ok(format!("{class}({})", shape_and_dtype(py, shape, dtype)?))
+}
+
+/// Build the repr of an array, which reads `Class(path='/a', shape=[4, 4], dtype='int32')`.
+///
+/// The path comes first, because it is what tells two arrays of one store apart.
+pub(crate) fn array_repr(
+    py: Python,
+    class: &str,
+    path: &PyNodePath,
+    shape: &[u64],
+    dtype: &PyDataType,
+) -> PyResult<String> {
+    let path = path.repr(py)?;
+    Ok(format!(
+        "{class}(path={path}, {})",
+        shape_and_dtype(py, shape, dtype)?
+    ))
 }

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -18,7 +18,7 @@
 use std::borrow::Cow;
 
 use pyo3::prelude::*;
-use pyo3::types::{PyList, PyString};
+use pyo3::types::{PyString, PyTuple};
 
 use crate::dtype::PyDataType;
 use crate::metadata::PyConfiguration;
@@ -49,17 +49,17 @@ pub(crate) fn named_config_repr(
     Ok(format!("{class}({})", parts.join(", ")))
 }
 
-/// Render `shape=[4, 4], dtype='int32'`, which every array-like repr ends with.
+/// Render `shape=(4, 4), dtype='int32'`, which every array-like repr ends with.
 ///
 /// The data type shows its Zarr v3 name. A data type that Zarr v3 does not name
 /// shows `None`, because no shorter description of it exists.
 fn shape_and_dtype(py: Python, shape: &[u64], dtype: &PyDataType) -> PyResult<String> {
-    let shape = PyList::new(py, shape)?.repr()?;
+    let shape = PyTuple::new(py, shape)?.repr()?;
     let dtype = dtype.name().into_pyobject(py)?.repr()?;
     Ok(format!("shape={shape}, dtype={dtype}"))
 }
 
-/// Build the repr of a decoded array, which reads `Class(shape=[4, 4], dtype='int32')`.
+/// Build the repr of a decoded array, which reads `Class(shape=(4, 4), dtype='int32')`.
 pub(crate) fn decoded_array_repr(
     py: Python,
     class: &str,
@@ -69,7 +69,7 @@ pub(crate) fn decoded_array_repr(
     Ok(format!("{class}({})", shape_and_dtype(py, shape, dtype)?))
 }
 
-/// Build the repr of an array, which reads `Class(path='/a', shape=[4, 4], dtype='int32')`.
+/// Build the repr of an array, which reads `Class(path='/a', shape=(4, 4), dtype='int32')`.
 ///
 /// The path comes first, because it is what tells two arrays of one store apart.
 pub(crate) fn array_repr(

--- a/src/storage/async.rs
+++ b/src/storage/async.rs
@@ -205,6 +205,7 @@ impl<'py> IntoPyObject<'py> for &PyAsyncIcechunkStore {
 pub struct PyAsyncZipStore {
     storage: Arc<AsyncReadOnlyStorageAdapter>,
     key: StoreKey,
+    path: Option<StorePrefix>,
 }
 
 crate::wasm_send_sync!(PyAsyncZipStore);
@@ -224,10 +225,12 @@ impl PyAsyncZipStore {
         path: Option<PyZipPath>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let key = key.into_inner();
+        let path = path.map(|p| p.into_inner());
 
         future_into_py(py, async move {
-            let adapter = if let Some(path) = path {
-                ZipStorageAdapter::new_with_path_async(store.inner(), key.clone(), path).await
+            let adapter = if let Some(path) = &path {
+                ZipStorageAdapter::new_with_path_async(store.inner(), key.clone(), path.as_str())
+                    .await
             } else {
                 ZipStorageAdapter::new_async(store.inner(), key.clone()).await
             }
@@ -235,12 +238,24 @@ impl PyAsyncZipStore {
             Ok(Self {
                 storage: Arc::new(AsyncReadOnlyStorageAdapter::new(Arc::new(adapter))),
                 key,
+                path,
             })
         })
     }
 
-    fn __repr__(&self) -> String {
-        format!("AsyncZipStore({})", self.key.as_str())
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        if let Some(path) = &self.path {
+            Ok(format!(
+                "AsyncZipStore(key={}, path={})",
+                self.key.as_str().into_pyobject(py)?.repr()?,
+                path.as_str().into_pyobject(py)?.repr()?
+            ))
+        } else {
+            Ok(format!(
+                "AsyncZipStore(key={})",
+                self.key.as_str().into_pyobject(py)?.repr()?
+            ))
+        }
     }
 }
 

--- a/src/storage/async.rs
+++ b/src/storage/async.rs
@@ -205,6 +205,7 @@ impl<'py> IntoPyObject<'py> for &PyAsyncIcechunkStore {
 pub struct PyAsyncZipStore {
     storage: Arc<AsyncReadOnlyStorageAdapter>,
     key: StoreKey,
+    /// The directory inside the zip file, or `None` for the whole file.
     path: Option<StorePrefix>,
 }
 
@@ -225,7 +226,10 @@ impl PyAsyncZipStore {
         path: Option<PyZipPath>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let key = key.into_inner();
-        let path = path.map(|p| p.into_inner());
+        // Convert `path=""` to `None`
+        let path = path
+            .map(|p| p.into_inner())
+            .filter(|p| !p.as_str().is_empty());
 
         future_into_py(py, async move {
             let adapter = if let Some(path) = &path {

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
+use pyo3::types::PyString;
 use zarrs::filesystem::FilesystemStore;
 use zarrs::storage::byte_range::{ByteRange, ByteRangeIterator};
 use zarrs::storage::store::MemoryStore;
@@ -90,8 +91,9 @@ impl PyFilesystemStore {
         })
     }
 
-    fn __repr__(&self) -> String {
-        format!("FilesystemStore({})", self.path.display())
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        let path = PyString::new(py, &self.path.to_string_lossy()).repr()?;
+        Ok(format!("FilesystemStore(path={path})"))
     }
 }
 
@@ -120,6 +122,7 @@ impl PyMemoryStore {
 pub struct PyZipStore {
     storage: Arc<ReadOnlyStorageAdapter>,
     key: StoreKey,
+    path: Option<StorePrefix>,
 }
 
 crate::wasm_send_sync!(PyZipStore);
@@ -139,9 +142,11 @@ impl PyZipStore {
         path: Option<PyZipPath>,
     ) -> ZarristaResult<Self> {
         let key = key.into_inner();
+        let path = path.map(|p| p.into_inner());
+
         let adapter = crate::py::detach(py, || {
-            if let Some(path) = path {
-                ZipStorageAdapter::new_with_path(store.inner(), key.clone(), path)
+            if let Some(path) = &path {
+                ZipStorageAdapter::new_with_path(store.inner(), key.clone(), path.as_str())
             } else {
                 ZipStorageAdapter::new(store.inner(), key.clone())
             }
@@ -149,6 +154,7 @@ impl PyZipStore {
         Ok(Self {
             storage: Arc::new(ReadOnlyStorageAdapter::new(Arc::new(adapter))),
             key,
+            path,
         })
     }
 
@@ -169,8 +175,19 @@ impl PyZipStore {
         Self::new(py, store, key, path)
     }
 
-    fn __repr__(&self) -> String {
-        format!("ZipStore({})", self.key.as_str())
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        if let Some(path) = &self.path {
+            Ok(format!(
+                "ZipStore(key={}, path={})",
+                self.key.as_str().into_pyobject(py)?.repr()?,
+                path.as_str().into_pyobject(py)?.repr()?
+            ))
+        } else {
+            Ok(format!(
+                "ZipStore(key={})",
+                self.key.as_str().into_pyobject(py)?.repr()?
+            ))
+        }
     }
 }
 

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -122,6 +122,7 @@ impl PyMemoryStore {
 pub struct PyZipStore {
     storage: Arc<ReadOnlyStorageAdapter>,
     key: StoreKey,
+    /// The directory inside the zip file, or `None` for the whole file.
     path: Option<StorePrefix>,
 }
 
@@ -142,7 +143,10 @@ impl PyZipStore {
         path: Option<PyZipPath>,
     ) -> ZarristaResult<Self> {
         let key = key.into_inner();
-        let path = path.map(|p| p.into_inner());
+        // Convert `path=""` to `None`
+        let path = path
+            .map(|p| p.into_inner())
+            .filter(|p| !p.as_str().is_empty());
 
         let adapter = crate::py::detach(py, || {
             if let Some(path) = &path {

--- a/src/storage/type_wrappers.rs
+++ b/src/storage/type_wrappers.rs
@@ -80,6 +80,12 @@ impl From<StoreKey> for PyStoreKey {
 /// select the same directory.
 pub struct PyZipPath(StorePrefix);
 
+impl PyZipPath {
+    pub(crate) fn into_inner(self) -> StorePrefix {
+        self.0
+    }
+}
+
 impl FromPyObject<'_, '_> for PyZipPath {
     type Error = PyErr;
 

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -45,4 +45,5 @@ def test_eq_non_dtype_is_false():
 
 
 def test_repr():
-    assert repr(DataType.from_string("float32")) == "DataType(float32 / <f4)"
+    """The repr shows the Zarr v3 name, not the numpy descr."""
+    assert repr(DataType.from_string("float32")) == "DataType('float32')"

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -75,7 +75,7 @@ def test_tensor_repr(tmp_path: Path) -> None:
 
     tensor = Array.open(FilesystemStore(tmp_path))[:, :]
 
-    assert repr(tensor) == "Tensor(shape=[4, 4], dtype='int32')"
+    assert repr(tensor) == "Tensor(shape=(4, 4), dtype='int32')"
 
 
 def test_variable_array_repr(tmp_path: Path) -> None:
@@ -85,4 +85,5 @@ def test_variable_array_repr(tmp_path: Path) -> None:
 
     variable = Array.open(FilesystemStore(tmp_path))[:]
 
-    assert repr(variable) == "VariableArray(shape=[3], dtype='string')"
+    assert repr(variable) == "VariableArray(shape=(3,), dtype='string')"
+

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -16,8 +16,8 @@ import numpy as np
 import pytest
 import zarr
 
-from zarrista import Array, ChunkKeyEncoding, codec
-from zarrista.store import FilesystemStore
+from zarrista import Array, ChunkKeyEncoding, Group, codec
+from zarrista.store import FilesystemStore, MemoryStore
 
 # `Debug` output looks like `ZstdCodec { compression: 3 }`: a Rust type name in
 # UpperCamelCase, then a brace. Python's dict repr never matches this.
@@ -87,3 +87,43 @@ def test_variable_array_repr(tmp_path: Path) -> None:
 
     assert repr(variable) == "VariableArray(shape=(3,), dtype='string')"
 
+
+def test_array_and_group_repr(tmp_path: Path) -> None:
+    """The path comes first, because it tells two arrays of one store apart."""
+    zarr.open_group(store=str(tmp_path), mode="w")
+    array = zarr.create_array(
+        store=str(tmp_path),
+        name="temperature",
+        shape=(4, 4),
+        chunks=(2, 2),
+        dtype="float32",
+    )
+    array[:] = np.zeros((4, 4), dtype="float32")
+    store = FilesystemStore(tmp_path)
+
+    assert (
+        repr(Array.open(store, "/temperature"))
+        == "Array(path='/temperature', shape=(4, 4), dtype='float32')"
+    )
+    assert repr(Group.open(store)) == "Group(path='/')"
+
+
+def test_shard_cache_repr_nests_the_array(tmp_path: Path) -> None:
+    array = zarr.create_array(
+        store=str(tmp_path),
+        shape=(4, 4),
+        chunks=(2, 2),
+        dtype="int32",
+    )
+    array[:] = np.zeros((4, 4), dtype="int32")
+
+    cache = Array.open(FilesystemStore(tmp_path)).shard_cache()
+
+    assert (
+        repr(cache) == "ShardCache(array=Array(path='/', shape=(4, 4), dtype='int32'))"
+    )
+
+
+def test_store_repr_names_its_argument() -> None:
+    assert repr(FilesystemStore("/data")) == "FilesystemStore(path='/data')"
+    assert repr(MemoryStore()) == "MemoryStore()"

--- a/tests/test_zip_store.py
+++ b/tests/test_zip_store.py
@@ -59,7 +59,7 @@ def test_open_matches_constructor(zipped: Path):
 
 
 def test_repr(zipped: Path):
-    assert repr(ZipStore(FilesystemStore(zipped), "a.zip")) == "ZipStore(a.zip)"
+    assert repr(ZipStore(FilesystemStore(zipped), "a.zip")) == "ZipStore(key='a.zip')"
 
 
 def test_array_storage_round_trips(zipped: Path):

--- a/tests/test_zip_store.py
+++ b/tests/test_zip_store.py
@@ -62,6 +62,23 @@ def test_repr(zipped: Path):
     assert repr(ZipStore(FilesystemStore(zipped), "a.zip")) == "ZipStore(key='a.zip')"
 
 
+@pytest.mark.parametrize("path", [None, "", "/"])
+def test_repr_omits_a_path_that_selects_the_whole_zip(zipped: Path, path: str | None):
+    """`''` and `'/'` normalize to the root, which is what `None` already means."""
+    store = ZipStore(FilesystemStore(zipped), "a.zip", path=path)
+
+    assert repr(store) == "ZipStore(key='a.zip')"
+
+
+@pytest.mark.parametrize("path", ["nested", "nested/", "/nested/"])
+def test_repr_shows_the_normalized_path(tmp_path: Path, path: str):
+    """Every spelling of one directory reprs as the value the store matches on."""
+    root = _zip_zarr(tmp_path, "a.zip", prefix="nested/")
+    store = ZipStore(FilesystemStore(root), "a.zip", path=path)
+
+    assert repr(store) == "ZipStore(key='a.zip', path='nested/')"
+
+
 def test_array_storage_round_trips(zipped: Path):
     store = ZipStore(FilesystemStore(zipped), "a.zip")
     assert isinstance(Array.open(store).storage, ZipStore)


### PR DESCRIPTION
Improved `repr`s for `Array`, `AsyncArray`, `Group`, `AsyncGroup`, `ZipStore`, `AsyncZipStore`