### PR TITLE
feat: Support setting attrs and consolidated metadata on `Group`

### DIFF
--- a/python/zarrista/_group.pyi
+++ b/python/zarrista/_group.pyi
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 from zarr_metadata import (
     JSONValue,
     ZarrV3ConsolidatedMetadataJSON,
@@ -106,6 +108,39 @@ class Group:
         """Write the group metadata to the store.
 
         This overwrites any metadata that exists at the group's path.
+        """
+    def with_attrs(self, attrs: Mapping[str, JSONValue]) -> Group:
+        """Return a new group reference with `attrs`, leaving this one unchanged.
+
+        The new attributes replace the old ones. Any key that `attrs` does not
+        contain is gone from the new group reference. To keep the existing
+        attributes, merge them yourself:
+
+        ```py
+        group = group.with_attrs({**group.attrs, "title": "root"})
+        ```
+
+        Nothing is persisted to the store. Call
+        [`Group.store_metadata`][zarrista.Group.store_metadata] to persist the new
+        attributes to the store:
+
+        ```py
+        group = group.with_attrs({"title": "root"})
+        group.store_metadata()
+        ```
+
+        This group is unaffected and remains usable; it simply goes on describing
+        the old attributes. Rebinding, as above, is the intended usage.
+
+        Args:
+            attrs: The user attributes of the new group reference. Each value
+                must be JSON-serializable.
+
+        Returns:
+            A new group reference that uses `attrs`.
+
+        Raises:
+            TypeError: If a value in `attrs` is not JSON-serializable.
         """
     @property
     def storage(self) -> SyncStore:
@@ -223,6 +258,39 @@ class AsyncGroup:
 
         Raises:
             KeyError: If the group has no direct child with that name.
+        """
+    def with_attrs(self, attrs: Mapping[str, JSONValue]) -> AsyncGroup:
+        """Return a new group reference with `attrs`, leaving this one unchanged.
+
+        The new attributes replace the old ones. Any key that `attrs` does not
+        contain is gone from the new group reference. To keep the existing
+        attributes, merge them yourself:
+
+        ```py
+        group = group.with_attrs({**group.attrs, "title": "root"})
+        ```
+
+        Nothing is persisted to the store. Call
+        [`AsyncGroup.store_metadata`][zarrista.AsyncGroup.store_metadata] to
+        persist the new attributes to the store:
+
+        ```py
+        group = group.with_attrs({"title": "root"})
+        await group.store_metadata()
+        ```
+
+        This group is unaffected and remains usable; it simply goes on describing
+        the old attributes. Rebinding, as above, is the intended usage.
+
+        Args:
+            attrs: The user attributes of the new group reference. Each value
+                must be JSON-serializable.
+
+        Returns:
+            A new group reference that uses `attrs`.
+
+        Raises:
+            TypeError: If a value in `attrs` is not JSON-serializable.
         """
     @property
     def storage(self) -> AsyncStore:

--- a/python/zarrista/_group.pyi
+++ b/python/zarrista/_group.pyi
@@ -142,6 +142,41 @@ class Group:
         Raises:
             TypeError: If a value in `attrs` is not JSON-serializable.
         """
+    def with_consolidated_metadata(
+        self,
+        consolidated_metadata: ZarrV3ConsolidatedMetadataJSON | None,
+    ) -> Group:
+        """Return a new group reference with `consolidated_metadata`.
+
+        This group is unchanged. Pass `None` to remove the consolidated metadata
+        from the new group reference.
+
+        This does not build the consolidated metadata. It stores the block that
+        you give it, and it does not check the block against the hierarchy.
+
+        Nothing is persisted to the store. Call
+        [`Group.store_metadata`][zarrista.Group.store_metadata] to persist the new
+        block to the store:
+
+        ```py
+        group = group.with_consolidated_metadata(consolidated_metadata)
+        group.store_metadata()
+        ```
+
+        Args:
+            consolidated_metadata: The consolidated metadata of the new group
+                reference, or `None` to remove it. The block has the same shape
+                that
+                [`Group.consolidated_metadata`][zarrista.Group.consolidated_metadata]
+                returns.
+
+        Returns:
+            A new group reference that uses `consolidated_metadata`.
+
+        Raises:
+            ValueError: If the group holds Zarr V2 metadata. Consolidated
+                metadata is a Zarr V3 convention.
+        """
     @property
     def storage(self) -> SyncStore:
         """The store that backs this group."""
@@ -291,6 +326,41 @@ class AsyncGroup:
 
         Raises:
             TypeError: If a value in `attrs` is not JSON-serializable.
+        """
+    def with_consolidated_metadata(
+        self,
+        consolidated_metadata: ZarrV3ConsolidatedMetadataJSON | None,
+    ) -> AsyncGroup:
+        """Return a new group reference with `consolidated_metadata`.
+
+        This group is unchanged. Pass `None` to remove the consolidated metadata
+        from the new group reference.
+
+        This does not build the consolidated metadata. It stores the block that
+        you give it, and it does not check the block against the hierarchy.
+
+        Nothing is persisted to the store. Call
+        [`AsyncGroup.store_metadata`][zarrista.AsyncGroup.store_metadata] to
+        persist the new block to the store:
+
+        ```py
+        group = group.with_consolidated_metadata(consolidated_metadata)
+        await group.store_metadata()
+        ```
+
+        Args:
+            consolidated_metadata: The consolidated metadata of the new group
+                reference, or `None` to remove it. The block has the same shape
+                that
+                [`AsyncGroup.consolidated_metadata`][zarrista.AsyncGroup.consolidated_metadata]
+                returns.
+
+        Returns:
+            A new group reference that uses `consolidated_metadata`.
+
+        Raises:
+            ValueError: If the group holds Zarr V2 metadata. Consolidated
+                metadata is a Zarr V3 convention.
         """
     @property
     def storage(self) -> AsyncStore:

--- a/src/group/shared.rs
+++ b/src/group/shared.rs
@@ -32,6 +32,27 @@ macro_rules! group_metadata_accessors {
             fn path(&self) -> &str {
                 self.inner.path().as_str()
             }
+
+            /// Return a new group reference with `attrs`, leaving this one unchanged.
+            fn with_attrs(
+                &self,
+                attrs: $crate::metadata::PyAttributes,
+            ) -> $crate::error::ZarristaResult<Self> {
+                // Workaround for missing Clone
+                // Clone added in
+                // https://github.com/zarrs/zarrs/pull/441
+                // and available in zarrs 0.24
+                let mut updated = ::zarrs::group::Group::new_with_metadata(
+                    self.inner.storage(),
+                    self.inner.path().as_str(),
+                    self.inner.metadata().clone(),
+                )?;
+                *updated.attributes_mut() = attrs.into_inner();
+                Ok(Self::new(
+                    ::std::sync::Arc::new(updated),
+                    self.store.clone(),
+                ))
+            }
         }
     };
 }

--- a/src/group/shared.rs
+++ b/src/group/shared.rs
@@ -53,6 +53,34 @@ macro_rules! group_metadata_accessors {
                     self.store.clone(),
                 ))
             }
+
+            /// Return a new group reference with `consolidated_metadata`, leaving this one unchanged.
+            fn with_consolidated_metadata(
+                &self,
+                consolidated_metadata: Option<$crate::metadata::PyConsolidatedMetadata>,
+            ) -> $crate::error::ZarristaResult<Self> {
+                // zarrs makes `set_consolidated_metadata` a no-op on V2 metadata, which
+                // would silently drop the caller's block.
+                if matches!(self.inner.metadata(), ::zarrs::group::GroupMetadata::V2(_)) {
+                    return Err(::pyo3::exceptions::PyValueError::new_err(
+                        "Consolidated metadata is not supported for Zarr V2 groups",
+                    )
+                    .into());
+                }
+
+                // Workaround for missing Clone; see `with_attrs`.
+                // Clone should be available in zarrs 0.24
+                let mut updated = ::zarrs::group::Group::new_with_metadata(
+                    self.inner.storage(),
+                    self.inner.path().as_str(),
+                    self.inner.metadata().clone(),
+                )?;
+                updated.set_consolidated_metadata(consolidated_metadata.map(|m| m.into()));
+                Ok(Self::new(
+                    ::std::sync::Arc::new(updated),
+                    self.store.clone(),
+                ))
+            }
         }
     };
 }

--- a/tests/test_group_with_attrs.py
+++ b/tests/test_group_with_attrs.py
@@ -1,0 +1,61 @@
+"""`Group.with_attrs()` returns a new group with new attributes, without writing."""
+
+from pathlib import Path
+
+import pytest
+import zarr
+from obstore.store import LocalStore
+
+from zarrista import AsyncGroup, Group
+from zarrista.store import FilesystemStore
+
+
+@pytest.fixture
+def hierarchy(tmp_path: Path) -> Path:
+    """A root group with two user attributes; returns the store path."""
+    path = tmp_path / "h.zarr"
+    root = zarr.open_group(store=str(path), mode="w")
+    root.attrs["title"] = "root"
+    root.attrs["institution"] = "example"
+    return path
+
+
+def test_with_attrs_replaces_attrs_and_leaves_the_original(hierarchy: Path):
+    group = Group.open(FilesystemStore(hierarchy))
+
+    updated = group.with_attrs({"title": "renamed"})
+
+    # `institution` is absent, so the new attributes replace rather than merge.
+    assert updated.attrs == {"title": "renamed"}
+    assert group.attrs == {"title": "root", "institution": "example"}
+    assert updated.path == group.path
+
+
+def test_nothing_is_written_until_store_metadata(hierarchy: Path):
+    updated = Group.open(FilesystemStore(hierarchy)).with_attrs({"title": "renamed"})
+    assert Group.open(FilesystemStore(hierarchy)).attrs["title"] == "root"
+
+    updated.store_metadata()
+
+    stored = Group.open(FilesystemStore(hierarchy)).attrs
+    assert stored["title"] == "renamed"
+    assert "institution" not in stored
+
+
+def test_a_value_that_is_not_json_serializable_raises(hierarchy: Path):
+    group = Group.open(FilesystemStore(hierarchy))
+
+    with pytest.raises(TypeError):
+        group.with_attrs({"bad": object()})
+
+
+async def test_async_with_attrs(hierarchy: Path):
+    group = await AsyncGroup.open(LocalStore(str(hierarchy)))
+
+    updated = group.with_attrs({"title": "renamed"})
+    await updated.store_metadata()
+
+    assert updated.attrs == {"title": "renamed"}
+    assert group.attrs == {"title": "root", "institution": "example"}
+    reopened = await AsyncGroup.open(LocalStore(str(hierarchy)))
+    assert reopened.attrs["title"] == "renamed"

--- a/tests/test_group_with_consolidated_metadata.py
+++ b/tests/test_group_with_consolidated_metadata.py
@@ -1,0 +1,92 @@
+"""`Group.with_consolidated_metadata()` sets or clears the block, without writing."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import zarr
+from obstore.store import LocalStore
+
+from zarrista import Array, AsyncGroup, Group
+from zarrista.store import FilesystemStore
+
+
+@pytest.fixture
+def hierarchy(tmp_path: Path) -> Path:
+    """A root group with one child array `a0`; returns the store path."""
+    path = tmp_path / "h.zarr"
+    root = zarr.open_group(store=str(path), mode="w")
+    root.create_array("a0", shape=(4,), chunks=(2,), dtype="int32")
+    return path
+
+
+@pytest.fixture
+def consolidated(hierarchy: Path) -> dict[str, Any]:
+    """A consolidated metadata block that describes the `a0` array."""
+    array = Array.open(FilesystemStore(hierarchy), "/a0")
+    return {
+        "kind": "inline",
+        "must_understand": False,
+        "metadata": {"a0": array.metadata},
+    }
+
+
+def test_with_consolidated_metadata_leaves_the_original(
+    hierarchy: Path,
+    consolidated: dict[str, Any],
+):
+    group = Group.open(FilesystemStore(hierarchy))
+
+    updated = group.with_consolidated_metadata(consolidated)
+
+    assert updated.consolidated_metadata is not None
+    assert updated.consolidated_metadata["kind"] == "inline"
+    assert list(updated.consolidated_metadata["metadata"]) == ["a0"]
+    assert group.consolidated_metadata is None
+
+
+def test_none_clears_the_block(hierarchy: Path, consolidated: dict[str, Any]):
+    group = Group.open(FilesystemStore(hierarchy)).with_consolidated_metadata(
+        consolidated,
+    )
+
+    assert group.with_consolidated_metadata(None).consolidated_metadata is None
+
+
+def test_nothing_is_written_until_store_metadata(
+    hierarchy: Path,
+    consolidated: dict[str, Any],
+):
+    updated = Group.open(FilesystemStore(hierarchy)).with_consolidated_metadata(
+        consolidated,
+    )
+    assert Group.open(FilesystemStore(hierarchy)).consolidated_metadata is None
+
+    updated.store_metadata()
+
+    stored = Group.open(FilesystemStore(hierarchy)).consolidated_metadata
+    assert stored is not None
+    assert stored["metadata"]["a0"]["shape"] == [4]
+
+
+def test_a_zarr_v2_group_raises(tmp_path: Path, consolidated: dict[str, Any]):
+    path = tmp_path / "v2.zarr"
+    zarr.open_group(store=str(path), mode="w", zarr_format=2)
+    group = Group.open(FilesystemStore(path))
+
+    with pytest.raises(ValueError, match="Zarr V2"):
+        group.with_consolidated_metadata(consolidated)
+
+
+async def test_async_with_consolidated_metadata(
+    hierarchy: Path,
+    consolidated: dict[str, Any],
+):
+    group = await AsyncGroup.open(LocalStore(str(hierarchy)))
+
+    updated = group.with_consolidated_metadata(consolidated)
+    await updated.store_metadata()
+
+    assert group.consolidated_metadata is None
+    reopened = await AsyncGroup.open(LocalStore(str(hierarchy)))
+    assert reopened.consolidated_metadata is not None


### PR DESCRIPTION
This is related to https://github.com/developmentseed/zarrista/issues/158. It allows writing consolidated metadata but doesn't support creating it directly.