### PR TITLE
refactor!: Positional-only param API review

### DIFF
--- a/.claude/skills/auditing-api-docs/SKILL.md
+++ b/.claude/skills/auditing-api-docs/SKILL.md
@@ -21,6 +21,9 @@ The audit therefore reads the built HTML, not the build log.
 - After changing a `:::` directive path, `mkdocs.yml`, or the `_zarrista` stubs.
 - When a reader reports that a type in a signature is not clickable.
 
+Cutting a release? Use `preparing-a-release`, which runs this audit as one step
+of a wider API review.
+
 ## The audit
 
 ```bash

--- a/.claude/skills/auditing-api-docs/check_api_parity.py
+++ b/.claude/skills/auditing-api-docs/check_api_parity.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Compare every `.pyi` signature against the signature the extension exposes.
+
+Nothing else catches a drift between the two: pydoclint checks a docstring
+against its own stub, mkdocs checks references, and pytest only covers what the
+tests call. A stub can therefore promise a parameter the Rust never accepts.
+
+Usage:
+    uv run --no-project python .claude/skills/auditing-api-docs/check_api_parity.py
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import pathlib
+import sys
+
+MODULES = ["zarrista", "zarrista.store", "zarrista.codec", "zarrista.exceptions"]
+STUBS = pathlib.Path("python/zarrista")
+
+KIND = {
+    inspect.Parameter.POSITIONAL_ONLY: "pos-only",
+    inspect.Parameter.POSITIONAL_OR_KEYWORD: "pos-or-kw",
+    inspect.Parameter.KEYWORD_ONLY: "kw-only",
+    inspect.Parameter.VAR_POSITIONAL: "*args",
+    inspect.Parameter.VAR_KEYWORD: "**kwargs",
+}
+
+
+def public_objects() -> dict[str, object]:
+    """Map every public name in the package to the object it names."""
+    found: dict[str, object] = {}
+    for name in MODULES:
+        module = importlib.import_module(name)
+        for attribute in dir(module):
+            if not attribute.startswith("_"):
+                found.setdefault(attribute, getattr(module, attribute))
+    return found
+
+
+def stub_parameters(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[tuple[str, str]]:
+    """Return `(name, kind)` for each parameter the stub declares."""
+    args = fn.args
+    params = [(p.arg, "pos-only") for p in args.posonlyargs]
+    params += [(p.arg, "pos-or-kw") for p in args.args]
+    if args.vararg:
+        params.append((args.vararg.arg, "*args"))
+    params += [(p.arg, "kw-only") for p in args.kwonlyargs]
+    if args.kwarg:
+        params.append((args.kwarg.arg, "**kwargs"))
+    return [p for p in params if p[0] != "self"]
+
+
+def runtime_parameters(member: object) -> list[tuple[str, str]] | None:
+    """Return `(name, kind)` per parameter, or `None` when pyo3 exposes none."""
+    try:
+        signature = inspect.signature(member)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    params = [(n, KIND[p.kind]) for n, p in signature.parameters.items() if n != "self"]
+    if params and params[0][0] in {"args", "kwargs"}:
+        return None  # an opaque `(*args, **kwargs)` carries no information
+    return params
+
+
+def compare_class(cls: ast.ClassDef, target: object) -> int:
+    """Report each method of `cls` whose stub disagrees with `target`."""
+    issues = 0
+    for fn in cls.body:
+        if not isinstance(fn, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        decorators = fn.decorator_list
+        if any(isinstance(d, ast.Name) and d.id == "property" for d in decorators):
+            continue
+        # Slot wrappers report the slot's own parameter names (`key`, `value`),
+        # which never match ours, and `__dlpack__` deliberately spells out
+        # keywords that Rust takes as `**kwargs`.
+        if fn.name.startswith("__") and fn.name != "__init__":
+            continue
+        attribute = "__new__" if fn.name == "__init__" else fn.name
+        member = getattr(target, attribute, None)
+        if member is None:
+            print(f"MISSING  {cls.name}.{fn.name}: in the stub, absent at runtime")
+            issues += 1
+            continue
+        runtime = runtime_parameters(member)
+        if runtime is None:
+            continue
+        stub = stub_parameters(fn)
+        if stub != runtime:
+            print(f"DIFF     {cls.name}.{fn.name}")
+            print(f"           stub:    {stub}")
+            print(f"           runtime: {runtime}")
+            issues += 1
+    return issues
+
+
+def main() -> int:
+    """Compare every stub signature with its runtime counterpart."""
+    objects = public_objects()
+    issues = 0
+    for path in sorted(STUBS.rglob("*.pyi")):
+        tree = ast.parse(path.read_text())
+        for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
+            target = objects.get(cls.name)
+            if target is not None:
+                issues += compare_class(cls, target)
+    print(f"signature mismatches: {issues}")
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/preparing-a-release/SKILL.md
+++ b/.claude/skills/preparing-a-release/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: preparing-a-release
+description: Use before cutting a zarrista release, and when reviewing any new or changed public API — a new `#[pymethods]` entry, a changed signature, a new `.pyi` class — to check the stub against the extension, settle positional-only and keyword-only markers while they are still free to change, and confirm every `Raises:` entry.
+---
+
+# Preparing a release
+
+## Overview
+
+The extension and its type stubs are written by hand in two places, and no tool
+in CI compares them. pydoclint checks a docstring against its own stub, mkdocs
+checks references, and pytest only exercises what a test calls. So a stub can
+promise a parameter that the Rust never accepts, and everything stays green.
+
+A release is the last cheap moment to fix a signature. After it, every parameter
+name and every calling convention is a compatibility promise.
+
+## When to use
+
+- Before cutting a release.
+- After adding or changing anything in a `#[pymethods]` block.
+- After adding a `.pyi` class or method.
+
+## 1. Stub against runtime
+
+```bash
+uv run --no-project maturin develop --uv
+uv run --no-project python .claude/skills/auditing-api-docs/check_api_parity.py
+```
+
+This compares each stub signature with `inspect.signature` of the object the
+extension exposes, and reports parameter names, order, and kinds
+(positional-only, keyword-only, `**kwargs`). It found `retrieve_array_subset`
+advertising `**codec_options` that the Rust did not take, and a `/` added to the
+async Rust but missed in the async stub.
+
+It skips dunders on purpose: CPython slot wrappers report the slot's own
+parameter names (`key`, `value`), which never match the stub's.
+
+## 2. Calling convention
+
+For each new or changed signature, decide the markers **now**:
+
+| Marker | Use when | Example |
+| --- | --- | --- |
+| `/` positional-only | the name adds nothing at the call site | `.shape(shape, /)`, `child(name, /)` |
+| `*` keyword-only | two adjacent parameters share a type, or the argument is an option | `regular(array_shape, *, chunk_shape)` |
+| neither | the caller may reasonably want to name it | `open(store, path="/")` |
+
+Notes that cost time to rediscover:
+
+- pyo3 **rejects** `signature` on magic methods. They are already
+  positional-only, so only the stub needs `/`.
+- A parameter that shadows a builtin (`bytes`) makes griffe resolve the
+  *annotation* to the parameter, which produces a broken docs link. Rename it.
+- With `**kwargs` present, a rejected keyword reports `missing 1 required
+  positional argument`, not "passed as keyword". Still an error, vaguer message.
+- Adding `/` or `*` after a release is breaking; removing either is not. Decide
+  early, and prefer the permissive option when genuinely unsure.
+
+## 3. Raises accuracy
+
+Confirm each `Raises:` entry by calling the built extension, per CLAUDE.md. The
+types are not always the obvious ones — a read-only array raises `ArrayError`
+from `store_chunk` but `StorageError` from `erase_chunk`.
+
+Each stub that documents an exception must also import it, or the docs link
+silently degrades to plain text. The docs audit catches that.
+
+## 4. Docs
+
+**REQUIRED SUB-SKILL:** run `auditing-api-docs` for the cross-reference,
+anchor, and `Returns:` checks.
+
+## 5. Gates
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+cargo +nightly-2026-06-01 fmt --all -- --check --unstable-features \
+    --config imports_granularity=Module,group_imports=StdExternalCrate
+uv run --no-project ruff check . && uv run --no-project ruff format --check .
+uv run --no-project pydoclint python $(find python -name '*.pyi')
+uv run --no-project pytest -q
+uv run --no-project mkdocs build --strict
+```
+
+Also build a wheel when the stub tree changed shape, and confirm the new files
+ship:
+
+```bash
+uv run --no-project maturin build --out dist
+python -c "import zipfile; print('\n'.join(zipfile.ZipFile('dist/<wheel>').namelist()))"
+```
+
+## Common mistakes
+
+- **Trusting a green suite.** Every failure this skill exists to catch passes
+  clippy, ruff, pydoclint, pytest, and `mkdocs --strict`.
+- **Verifying a check only against passing input.** A check that reports zero
+  may be broken. Feed it a known-bad case and confirm it complains.
+- **Changing the Rust and forgetting the async twin, or the stub.** Sync and
+  async are separate `#[pymethods]` blocks and separate stub classes; the shared
+  macros cover only the metadata accessors.
+- **Testing that an option is accepted rather than honored.** `f(x, validate=True)`
+  returning without error proves nothing if the option is parsed and dropped.
+  Corrupt the input and assert the behavior changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,6 @@ ignore = [
 known-first-party = ["zarrista"]
 
 [tool.ruff.lint.per-file-ignores]
-"*.pyi" = [
-    "A002", # Function argument `bytes` is shadowing a Python builtin
-]
 # Command-line scripts that support the skills in `.claude/skills`.
 ".claude/skills/*/*.py" = [
     "PLC0415", # import not at top-level (network imports stay in the one check that needs them)

--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -202,6 +202,7 @@ class Array:
     def retrieve_array_subset(
         self,
         selection: Selection,
+        /,
         **codec_options: Unpack[CodecOptions],
     ) -> Tensor:
         """Read and decode an array region selected with numpy-style basic indexing.
@@ -228,6 +229,7 @@ class Array:
     def retrieve_chunk(
         self,
         chunk_indices: list[int],
+        /,
         **codec_options: Unpack[CodecOptions],
     ) -> Tensor:
         """Read and decode the chunk at the given chunk grid indices.
@@ -264,6 +266,7 @@ class Array:
     def retrieve_subchunk(
         self,
         subchunk_indices: list[int],
+        /,
         *,
         shard_cache: ShardCache | None = None,
         **codec_options: Unpack[CodecOptions],
@@ -296,6 +299,7 @@ class Array:
     def retrieve_encoded_subchunk(
         self,
         subchunk_indices: list[int],
+        /,
         *,
         shard_cache: ShardCache | None = None,
     ) -> EncodedChunk | None:
@@ -351,6 +355,7 @@ class Array:
         self,
         selection: Selection,
         data: DataInput,
+        /,
         **codec_options: Unpack[CodecOptions],
     ) -> None:
         """Encode `data` and write it to the region selected by `selection`.
@@ -383,6 +388,7 @@ class Array:
         self,
         chunk_indices: list[int],
         decoded_chunk: ArrayBytes,
+        /,
         **codec_options: Unpack[CodecOptions],
     ) -> None:
         """Encode `decoded_chunk` and write it as the chunk at `chunk_indices`.
@@ -406,6 +412,7 @@ class Array:
         self,
         chunks: Selection,
         data: DataInput,
+        /,
         **codec_options: Unpack[CodecOptions],
     ) -> None:
         """Encode `data` and write it to the chunks selected by `chunks`.
@@ -473,6 +480,7 @@ class Array:
         self,
         chunk_indices: list[int],
         encoded_chunk: Buffer,
+        /,
     ) -> None:
         """Write already-encoded bytes directly as the chunk at `chunk_indices`.
 
@@ -502,6 +510,7 @@ class Array:
     def compact_chunk(
         self,
         chunk_indices: list[int],
+        /,
         **codec_options: Unpack[CodecOptions],
     ) -> bool:
         """Re-encode the stored chunk in place, and report whether it changed.
@@ -874,6 +883,7 @@ class AsyncArray:
     async def retrieve_array_subset(
         self,
         selection: Selection,
+        /,
         **codec_options: Unpack[CodecOptions],
     ) -> Tensor:
         """Read and decode an array region selected with numpy-style basic indexing.
@@ -900,6 +910,7 @@ class AsyncArray:
     async def retrieve_chunk(
         self,
         chunk_indices: list[int],
+        /,
         **codec_options: Unpack[CodecOptions],
     ) -> Tensor:
         """Read and decode the chunk at the given chunk grid indices.
@@ -935,6 +946,7 @@ class AsyncArray:
     async def retrieve_subchunk(
         self,
         subchunk_indices: list[int],
+        /,
         *,
         shard_cache: AsyncShardCache | None = None,
         **codec_options: Unpack[CodecOptions],
@@ -967,6 +979,7 @@ class AsyncArray:
     async def retrieve_encoded_subchunk(
         self,
         subchunk_indices: list[int],
+        /,
         *,
         shard_cache: AsyncShardCache | None = None,
     ) -> EncodedChunk | None:
@@ -1024,6 +1037,7 @@ class AsyncArray:
         self,
         selection: Selection,
         data: DataInput,
+        /,
         **codec_options: Unpack[CodecOptions],
     ) -> None:
         """Encode `data` and write it to the region selected by `selection`.
@@ -1056,6 +1070,7 @@ class AsyncArray:
         self,
         chunk_indices: list[int],
         decoded_chunk: ArrayBytes,
+        /,
         **codec_options: Unpack[CodecOptions],
     ) -> None:
         """Encode `decoded_chunk` and write it as the chunk at `chunk_indices`.
@@ -1079,6 +1094,7 @@ class AsyncArray:
         self,
         chunks: Selection,
         data: DataInput,
+        /,
         **codec_options: Unpack[CodecOptions],
     ) -> None:
         """Encode `data` and write it to the chunks selected by `chunks`.
@@ -1146,6 +1162,7 @@ class AsyncArray:
         self,
         chunk_indices: list[int],
         encoded_chunk: Buffer,
+        /,
     ) -> None:
         """Write already-encoded bytes directly as the chunk at `chunk_indices`.
 
@@ -1175,6 +1192,7 @@ class AsyncArray:
     async def compact_chunk(
         self,
         chunk_indices: list[int],
+        /,
         **codec_options: Unpack[CodecOptions],
     ) -> bool:
         """Re-encode the stored chunk in place, and report whether it changed.

--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -119,7 +119,7 @@ class Array:
     @property
     def chunk_grid_shape(self) -> list[int]:
         """The shape of the chunk grid (i.e. the number of chunks per dimension)."""
-    def chunk_key(self, chunk_indices: list[int]) -> str:
+    def chunk_key(self, chunk_indices: list[int], /) -> str:
         """Return the store key of the chunk at `chunk_indices`.
 
         This does not check `chunk_indices` against the chunk grid. It gives a
@@ -134,7 +134,7 @@ class Array:
     @property
     def chunk_key_encoding(self) -> ChunkKeyEncoding:
         """The chunk key encoding, mapping chunk grid indices to store keys."""
-    def chunk_origin(self, chunk_indices: list[int]) -> list[int]:
+    def chunk_origin(self, chunk_indices: list[int], /) -> list[int]:
         """Return the origin of the chunk at `chunk_indices`.
 
         Args:
@@ -147,7 +147,7 @@ class Array:
             ArrayError: If `chunk_indices` has a different number of dimensions
                 from the chunk grid.
         """
-    def chunk_shape(self, chunk_indices: list[int]) -> list[int]:
+    def chunk_shape(self, chunk_indices: list[int], /) -> list[int]:
         """Return the shape of the chunk at `chunk_indices`.
 
         Args:
@@ -160,7 +160,7 @@ class Array:
             ArrayError: If `chunk_indices` has a different number of dimensions
                 from the chunk grid.
         """
-    def chunk_subset(self, chunk_indices: list[int]) -> tuple[slice, ...]:
+    def chunk_subset(self, chunk_indices: list[int], /) -> tuple[slice, ...]:
         """Return the array subset spanned by the chunk at `chunk_indices`.
 
         Args:
@@ -243,7 +243,11 @@ class Array:
         Raises:
             TypeError: If a keyword argument is not a known codec option.
         """
-    def retrieve_encoded_chunk(self, chunk_indices: list[int]) -> EncodedChunk | None:
+    def retrieve_encoded_chunk(
+        self,
+        chunk_indices: list[int],
+        /,
+    ) -> EncodedChunk | None:
         """Read the raw, still-encoded bytes of the chunk at `chunk_indices`.
 
         The method reads the bytes and does not run the codec pipeline. To
@@ -519,7 +523,7 @@ class Array:
                 is read-only.
             TypeError: If a keyword argument is not a known codec option.
         """
-    def erase_chunk(self, chunk_indices: list[int]) -> None:
+    def erase_chunk(self, chunk_indices: list[int], /) -> None:
         """Delete the chunk at `chunk_indices` from the store.
 
         To erase a chunk that is absent does nothing.
@@ -530,7 +534,7 @@ class Array:
         Raises:
             StorageError: If the array is read-only.
         """
-    def erase_chunks(self, chunks: Selection) -> None:
+    def erase_chunks(self, chunks: Selection, /) -> None:
         """Delete the specified chunks from the store.
 
         `chunks` is a numpy-style selection in **chunk-grid** coordinates, not
@@ -565,7 +569,7 @@ class Array:
         Returns:
             A read-only view of this array.
         """
-    def with_chunk_grid(self, chunk_grid: ChunkGrid) -> Array:
+    def with_chunk_grid(self, chunk_grid: ChunkGrid, /) -> Array:
         """Return a new array reference with `chunk_grid`.
 
         This does not mutate the existing `array`.
@@ -603,7 +607,7 @@ class Array:
         Returns:
             A new array reference that uses `chunk_grid`.
         """
-    def with_attrs(self, attrs: Mapping[str, JSONValue]) -> Array:
+    def with_attrs(self, attrs: Mapping[str, JSONValue], /) -> Array:
         """Return a new array reference with `attrs`, leaving this one unchanged.
 
         The new attributes replace the old ones. Any key that `attrs` does not
@@ -641,7 +645,7 @@ class Array:
             TypeError: If a key is not a string, or if a value is not
                 JSON-serializable.
         """
-    def with_shape(self, shape: list[int]) -> Array:
+    def with_shape(self, shape: list[int], /) -> Array:
         """Return a new array reference with `shape`, leaving this one unchanged.
 
         Nothing is persisted to the store. Call
@@ -712,7 +716,7 @@ class Array:
     @property
     def subset_all(self) -> tuple[slice, ...]:
         """The array subset that spans the entire array, as a tuple of slices."""
-    def __getitem__(self, selection: Selection) -> Tensor:
+    def __getitem__(self, selection: Selection, /) -> Tensor:
         """Read a region with numpy-style basic indexing, e.g. `arr[0:10, :, 5]`.
 
         This is sugar for `retrieve_array_subset`.
@@ -787,7 +791,7 @@ class AsyncArray:
     @property
     def chunk_grid_shape(self) -> list[int]:
         """The shape of the chunk grid (i.e. the number of chunks per dimension)."""
-    def chunk_key(self, chunk_indices: list[int]) -> str:
+    def chunk_key(self, chunk_indices: list[int], /) -> str:
         """Return the store key of the chunk at `chunk_indices`.
 
         This does not check `chunk_indices` against the chunk grid. It gives a
@@ -802,7 +806,7 @@ class AsyncArray:
     @property
     def chunk_key_encoding(self) -> ChunkKeyEncoding:
         """The chunk key encoding, mapping chunk grid indices to store keys."""
-    def chunk_origin(self, chunk_indices: list[int]) -> list[int]:
+    def chunk_origin(self, chunk_indices: list[int], /) -> list[int]:
         """Return the origin of the chunk at `chunk_indices`.
 
         Args:
@@ -815,7 +819,7 @@ class AsyncArray:
             ArrayError: If `chunk_indices` has a different number of dimensions
                 from the chunk grid.
         """
-    def chunk_shape(self, chunk_indices: list[int]) -> list[int]:
+    def chunk_shape(self, chunk_indices: list[int], /) -> list[int]:
         """Return the shape of the chunk at `chunk_indices`.
 
         Args:
@@ -828,7 +832,7 @@ class AsyncArray:
             ArrayError: If `chunk_indices` has a different number of dimensions
                 from the chunk grid.
         """
-    def chunk_subset(self, chunk_indices: list[int]) -> tuple[slice, ...]:
+    def chunk_subset(self, chunk_indices: list[int], /) -> tuple[slice, ...]:
         """Return the array subset spanned by the chunk at `chunk_indices`.
 
         Args:
@@ -1192,7 +1196,7 @@ class AsyncArray:
                 is read-only.
             TypeError: If a keyword argument is not a known codec option.
         """
-    async def erase_chunk(self, chunk_indices: list[int]) -> None:
+    async def erase_chunk(self, chunk_indices: list[int], /) -> None:
         """Delete the chunk at `chunk_indices` from the store.
 
         To erase a chunk that is absent does nothing.
@@ -1203,7 +1207,7 @@ class AsyncArray:
         Raises:
             StorageError: If the array is read-only.
         """
-    async def erase_chunks(self, chunks: Selection) -> None:
+    async def erase_chunks(self, chunks: Selection, /) -> None:
         """Delete the specified chunks from the store.
 
         `chunks` is a numpy-style selection in **chunk-grid** coordinates, not
@@ -1238,7 +1242,7 @@ class AsyncArray:
         Returns:
             A read-only view of this array.
         """
-    def with_chunk_grid(self, chunk_grid: ChunkGrid) -> AsyncArray:
+    def with_chunk_grid(self, chunk_grid: ChunkGrid, /) -> AsyncArray:
         """Return a new array reference with `chunk_grid`, leaving this one unchanged.
 
         This method is synchronous: it performs no I/O. The new array's shape comes
@@ -1274,7 +1278,7 @@ class AsyncArray:
         Returns:
             A new array reference that uses `chunk_grid`.
         """
-    def with_attrs(self, attrs: Mapping[str, JSONValue]) -> AsyncArray:
+    def with_attrs(self, attrs: Mapping[str, JSONValue], /) -> AsyncArray:
         """Return a new array reference with `attrs`, leaving this one unchanged.
 
         The new attributes replace the old ones. Any key that `attrs` does not
@@ -1313,7 +1317,7 @@ class AsyncArray:
             TypeError: If a key is not a string, or if a value is not
                 JSON-serializable.
         """
-    def with_shape(self, shape: list[int]) -> AsyncArray:
+    def with_shape(self, shape: list[int], /) -> AsyncArray:
         """Return a new array reference with `shape`, leaving this one unchanged.
 
         This method is synchronous: it performs no I/O. Nothing is persisted to the
@@ -1385,7 +1389,7 @@ class AsyncArray:
     @property
     def subset_all(self) -> tuple[slice, ...]:
         """The array subset that spans the entire array, as a tuple of slices."""
-    async def __getitem__(self, selection: Selection) -> Tensor:
+    async def __getitem__(self, selection: Selection, /) -> Tensor:
         """Read a region with numpy-style basic indexing: `await arr[0:10, :, 5]`.
 
         This is sugar for `retrieve_array_subset`.

--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -929,6 +929,7 @@ class AsyncArray:
     async def retrieve_encoded_chunk(
         self,
         chunk_indices: list[int],
+        /,
     ) -> EncodedChunk | None:
         """Read the raw, still-encoded bytes of the chunk at `chunk_indices`.
 

--- a/python/zarrista/_array.pyi
+++ b/python/zarrista/_array.pyi
@@ -578,7 +578,7 @@ class Array:
         and the chunking together:
 
         ```py
-        array = array.with_chunk_grid(ChunkGrid.regular([8, 8], [4, 4]))
+        array = array.with_chunk_grid(ChunkGrid.regular([8, 8], chunk_shape=[4, 4]))
         array.store_metadata()
         ```
 
@@ -1249,7 +1249,7 @@ class AsyncArray:
         from the grid, so this can change the shape and the chunking together:
 
         ```py
-        array = array.with_chunk_grid(ChunkGrid.regular([8, 8], [4, 4]))
+        array = array.with_chunk_grid(ChunkGrid.regular([8, 8], chunk_shape=[4, 4]))
         await array.store_metadata()
         ```
 

--- a/python/zarrista/_array_bytes.pyi
+++ b/python/zarrista/_array_bytes.pyi
@@ -9,18 +9,19 @@ class ArrayBytes:
 
     def __init__(
         self,
-        bytes: Buffer,
+        value: Buffer,
+        /,
         *,
         mask: Buffer | None = None,
         offsets: list[int] | None = None,
     ) -> None:
         """Construct from a data buffer, with an optional mask and offsets.
 
-        This does not check `mask` or `offsets` against `bytes`. The codec
+        This does not check `mask` or `offsets` against `value`. The codec
         pipeline reports an error only when it uses the data.
 
         Args:
-            bytes: The element bytes.
+            value: The element bytes.
 
         Keyword Args:
             mask: The validity mask, with one byte per element. Give `None` for

--- a/python/zarrista/_builder.pyi
+++ b/python/zarrista/_builder.pyi
@@ -77,7 +77,7 @@ class ArrayBuilder:
             fill_value: The fill value of the array. This must match `dtype`.
         """
     @staticmethod
-    def like(array: Array | AsyncArray) -> ArrayBuilder:
+    def like(array: Array | AsyncArray, /) -> ArrayBuilder:
         """Create a builder that copies the configuration of an existing array.
 
         Args:
@@ -86,7 +86,7 @@ class ArrayBuilder:
         Returns:
             A new builder with the same configuration as `array`.
         """
-    def attrs(self, attrs: Mapping[str, JSONValue]) -> ArrayBuilder:
+    def attrs(self, attrs: Mapping[str, JSONValue], /) -> ArrayBuilder:
         """Return a new builder with the given user attributes set.
 
         Args:
@@ -95,7 +95,7 @@ class ArrayBuilder:
         Returns:
             A new builder with the user attributes set.
         """
-    def chunk_grid(self, chunk_grid: ChunkGrid) -> ArrayBuilder:
+    def chunk_grid(self, chunk_grid: ChunkGrid, /) -> ArrayBuilder:
         """Return a new builder with the chunk grid set.
 
         This can also change the array shape, because the grid carries one.
@@ -109,6 +109,7 @@ class ArrayBuilder:
     def chunk_key_encoding(
         self,
         chunk_key_encoding: ChunkKeyEncoding,
+        /,
     ) -> ArrayBuilder:
         """Return a new builder with the chunk key encoding set.
 
@@ -122,6 +123,7 @@ class ArrayBuilder:
     def compressors(
         self,
         compressors: Sequence[BytesToBytesCodec],
+        /,
     ) -> ArrayBuilder:
         """Return a new builder with the bytes-to-bytes codecs ("compressors") set.
 
@@ -131,7 +133,7 @@ class ArrayBuilder:
         Returns:
             A new builder with the compressors set.
         """
-    def data_type(self, data_type: DataType) -> ArrayBuilder:
+    def data_type(self, data_type: DataType, /) -> ArrayBuilder:
         """Return a new builder with the data type set.
 
         Args:
@@ -144,6 +146,7 @@ class ArrayBuilder:
     def dimension_names(
         self,
         dimension_names: Sequence[str | None] | None,
+        /,
     ) -> ArrayBuilder:
         """Return a new builder with the dimension names set (or cleared).
 
@@ -155,7 +158,7 @@ class ArrayBuilder:
         Returns:
             A new builder with the dimension names set.
         """
-    def filters(self, filters: Sequence[ArrayToArrayCodec]) -> ArrayBuilder:
+    def filters(self, filters: Sequence[ArrayToArrayCodec], /) -> ArrayBuilder:
         """Return a new builder with the array-to-array codecs ("filters") set.
 
         Args:
@@ -164,7 +167,7 @@ class ArrayBuilder:
         Returns:
             A new builder with the filters set.
         """
-    def serializer(self, serializer: ArrayToBytesCodec) -> ArrayBuilder:
+    def serializer(self, serializer: ArrayToBytesCodec, /) -> ArrayBuilder:
         """Return a new builder with the array-to-bytes codec ("serializer") set.
 
         Sharding is itself an array-to-bytes codec. Therefore you pass a
@@ -176,7 +179,7 @@ class ArrayBuilder:
         Returns:
             A new builder with the serializer set.
         """
-    def shape(self, shape: Sequence[int]) -> ArrayBuilder:
+    def shape(self, shape: Sequence[int], /) -> ArrayBuilder:
         """Return a new builder with the array shape set.
 
         This shape replaces the shape that the chunk grid gives.
@@ -190,6 +193,7 @@ class ArrayBuilder:
     def subchunk_shape(
         self,
         subchunk_shape: Sequence[int] | None,
+        /,
     ) -> ArrayBuilder:
         """Return a new builder with the inner (subchunk) shape, enabling sharding.
 

--- a/python/zarrista/_builder.pyi
+++ b/python/zarrista/_builder.pyi
@@ -38,7 +38,7 @@ class ArrayBuilder:
         from zarrista import ArrayBuilder, ChunkGrid, DataType, FillValue, codec
         from zarrista.store import FilesystemStore
 
-        grid = ChunkGrid.regular([1024, 1024], [256, 256])
+        grid = ChunkGrid.regular([1024, 1024], chunk_shape=[256, 256])
         dtype = DataType.from_string("int32")
         fill_value = FillValue((0).to_bytes(4, "little"))
 

--- a/python/zarrista/_chunk_key_encoding.pyi
+++ b/python/zarrista/_chunk_key_encoding.pyi
@@ -22,7 +22,7 @@ class ChunkKeyEncoding:
             ValueError: If `sep` is not `"."` or `"/"`.
         """
     @staticmethod
-    def from_metadata(metadata: ZarrV3NamedConfigJSON) -> ChunkKeyEncoding:
+    def from_metadata(metadata: ZarrV3NamedConfigJSON, /) -> ChunkKeyEncoding:
         """Construct a chunk key encoding from its Zarr v3 metadata.
 
         Args:

--- a/python/zarrista/_chunks.pyi
+++ b/python/zarrista/_chunks.pyi
@@ -31,7 +31,11 @@ class ChunkGrid:
     """
 
     @staticmethod
-    def regular(array_shape: Sequence[int], chunk_shape: Sequence[int]) -> ChunkGrid:
+    def regular(
+        array_shape: Sequence[int],
+        *,
+        chunk_shape: Sequence[int],
+    ) -> ChunkGrid:
         """Construct a regular grid with a fixed chunk shape.
 
         Args:
@@ -49,6 +53,7 @@ class ChunkGrid:
     @staticmethod
     def rectilinear(
         array_shape: Sequence[int],
+        *,
         chunk_shapes: Sequence[ChunkEdgeLengths],
     ) -> ChunkGrid:
         """Construct a rectilinear grid with different chunk sizes along each dimension.
@@ -68,6 +73,7 @@ class ChunkGrid:
     @staticmethod
     def regular_bounded(
         array_shape: Sequence[int],
+        *,
         chunk_shape: Sequence[int],
     ) -> ChunkGrid:
         """Construct a regular grid that clips the last chunks to the array bounds.

--- a/python/zarrista/_dtype.pyi
+++ b/python/zarrista/_dtype.pyi
@@ -54,7 +54,7 @@ class DataType:
     """A Zarr v3 data type."""
 
     @staticmethod
-    def from_metadata(metadata: ZarrV3NamedConfigJSON) -> DataType:
+    def from_metadata(metadata: ZarrV3NamedConfigJSON, /) -> DataType:
         """Construct a data type from its Zarr v3 metadata.
 
         Args:
@@ -68,7 +68,7 @@ class DataType:
                 or if the configuration is not valid for it.
         """
     @staticmethod
-    def from_string(name: DataTypeName | str) -> DataType:
+    def from_string(name: DataTypeName | str, /) -> DataType:
         """Construct a data type from its Zarr v3 name (e.g. `"float32"`).
 
         Args:
@@ -86,4 +86,4 @@ class DataType:
     @property
     def size(self) -> int | None:
         """The fixed size in bytes, or `None` for variable-length data types."""
-    def __eq__(self, other: object) -> bool: ...
+    def __eq__(self, other: object, /) -> bool: ...

--- a/python/zarrista/_fill_value.pyi
+++ b/python/zarrista/_fill_value.pyi
@@ -18,7 +18,7 @@ class FillValue:
         Returns:
             The native-endian bytes of one fill value element.
         """
-    def equals_all(self, other: Buffer) -> bool:
+    def equals_all(self, other: Buffer, /) -> bool:
         """Return whether `other` contains only repetitions of this fill value.
 
         Args:

--- a/python/zarrista/_group.pyi
+++ b/python/zarrista/_group.pyi
@@ -95,7 +95,7 @@ class Group:
 
         This succeeds if the metadata does not exist.
         """
-    def child(self, name: str) -> Array | Group:
+    def child(self, name: str, /) -> Array | Group:
         """Open a direct child array or group by name.
 
         Args:
@@ -112,7 +112,7 @@ class Group:
 
         This overwrites any metadata that exists at the group's path.
         """
-    def with_attrs(self, attrs: Mapping[str, JSONValue]) -> Group:
+    def with_attrs(self, attrs: Mapping[str, JSONValue], /) -> Group:
         """Return a new group reference with `attrs`, leaving this one unchanged.
 
         The new attributes replace the old ones. Any key that `attrs` does not
@@ -148,6 +148,7 @@ class Group:
     def with_consolidated_metadata(
         self,
         consolidated_metadata: ZarrV3ConsolidatedMetadataJSON | None,
+        /,
     ) -> Group:
         """Return a new group reference with `consolidated_metadata`.
 
@@ -183,7 +184,7 @@ class Group:
     @property
     def storage(self) -> SyncStore:
         """The store that backs this group."""
-    def __getitem__(self, name: str) -> Array | Group:
+    def __getitem__(self, name: str, /) -> Array | Group:
         """Open a direct child array or group by name.
 
         Args:
@@ -285,7 +286,7 @@ class AsyncGroup:
 
         This succeeds if the metadata does not exist.
         """
-    async def child(self, name: str) -> AsyncArray | AsyncGroup:
+    async def child(self, name: str, /) -> AsyncArray | AsyncGroup:
         """Open a direct child array or group by name.
 
         Args:
@@ -297,7 +298,7 @@ class AsyncGroup:
         Raises:
             KeyError: If the group has no direct child with that name.
         """
-    def with_attrs(self, attrs: Mapping[str, JSONValue]) -> AsyncGroup:
+    def with_attrs(self, attrs: Mapping[str, JSONValue], /) -> AsyncGroup:
         """Return a new group reference with `attrs`, leaving this one unchanged.
 
         The new attributes replace the old ones. Any key that `attrs` does not
@@ -333,6 +334,7 @@ class AsyncGroup:
     def with_consolidated_metadata(
         self,
         consolidated_metadata: ZarrV3ConsolidatedMetadataJSON | None,
+        /,
     ) -> AsyncGroup:
         """Return a new group reference with `consolidated_metadata`.
 

--- a/python/zarrista/codec/_array_to_array.pyi
+++ b/python/zarrista/codec/_array_to_array.pyi
@@ -21,7 +21,7 @@ class ArrayToArrayCodec:
     def config(self) -> JSONValue | None:
         """The codec's Zarr v3 configuration as a dict, if any."""
     @staticmethod
-    def from_config(metadata: JSONValue) -> ArrayToArrayCodec:
+    def from_config(metadata: JSONValue, /) -> ArrayToArrayCodec:
         """Construct a codec from its Zarr v3 metadata.
 
         Args:

--- a/python/zarrista/codec/_array_to_array.pyi
+++ b/python/zarrista/codec/_array_to_array.pyi
@@ -60,7 +60,8 @@ class ArrayToArrayCodec:
         """
     def encode(
         self,
-        bytes: ArrayBytes,
+        value: ArrayBytes,
+        /,
         shape: list[int],
         data_type: DataType,
         fill_value: FillValue,
@@ -68,7 +69,7 @@ class ArrayToArrayCodec:
         """Encode chunk bytes with this codec.
 
         Args:
-            bytes: The decoded chunk bytes.
+            value: The decoded chunk bytes.
             shape: The shape of the decoded chunk, in elements along each
                 dimension.
             data_type: The data type of the decoded chunk.
@@ -78,12 +79,13 @@ class ArrayToArrayCodec:
             The encoded chunk bytes.
 
         Raises:
-            CodecError: If `bytes` does not agree with `shape` and `data_type`,
+            CodecError: If `value` does not agree with `shape` and `data_type`,
                 or if the codec cannot encode the chunk.
         """
     def decode(
         self,
-        bytes: ArrayBytes,
+        value: ArrayBytes,
+        /,
         shape: list[int],
         data_type: DataType,
         fill_value: FillValue,
@@ -91,7 +93,7 @@ class ArrayToArrayCodec:
         """Decode chunk bytes with this codec.
 
         Args:
-            bytes: The encoded chunk bytes.
+            value: The encoded chunk bytes.
             shape: The shape of the encoded chunk, in elements along each
                 dimension.
             data_type: The data type of the encoded chunk.
@@ -101,7 +103,7 @@ class ArrayToArrayCodec:
             The decoded chunk bytes.
 
         Raises:
-            CodecError: If `bytes` does not agree with `shape` and `data_type`,
+            CodecError: If `value` does not agree with `shape` and `data_type`,
                 or if the codec cannot decode the chunk.
         """
     def encoded_shape(self, decoded_shape: list[int]) -> list[int]:

--- a/python/zarrista/codec/_array_to_bytes.pyi
+++ b/python/zarrista/codec/_array_to_bytes.pyi
@@ -13,7 +13,7 @@ class ArrayToBytesCodec:
     def config(self) -> JSONValue | None:
         """The codec's Zarr v3 configuration as a dict, if any."""
     @staticmethod
-    def from_config(metadata: JSONValue) -> ArrayToBytesCodec:
+    def from_config(metadata: JSONValue, /) -> ArrayToBytesCodec:
         """Construct a codec from its Zarr v3 metadata.
 
         Args:

--- a/python/zarrista/codec/_bytes_to_bytes/__init__.pyi
+++ b/python/zarrista/codec/_bytes_to_bytes/__init__.pyi
@@ -13,7 +13,7 @@ class BytesToBytesCodec:
     def config(self) -> JSONValue | None:
         """The codec's Zarr v3 configuration as a dict, if any."""
     @staticmethod
-    def from_config(metadata: JSONValue) -> BytesToBytesCodec:
+    def from_config(metadata: JSONValue, /) -> BytesToBytesCodec:
         """Construct a codec from its Zarr v3 metadata.
 
         Args:
@@ -27,7 +27,7 @@ class BytesToBytesCodec:
             PluginCreateError: If the metadata names an unsupported codec, or
                 if the configuration is not valid for that codec.
         """
-    def encode(self, decoded_value: bytes) -> bytes:
+    def encode(self, decoded_value: bytes, /) -> bytes:
         """Encode chunk bytes with this codec.
 
         Args:

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -65,7 +65,7 @@ impl PyAsyncArray {
         py: Python<'py>,
         selection: PySelection,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.retrieve_array_subset(py, selection)
+        self.retrieve_array_subset(py, selection, None)
     }
 
     fn __repr__(&self, py: Python) -> PyResult<String> {
@@ -185,18 +185,22 @@ impl PyAsyncArray {
     }
 
     /// Read a region of the array as `Data`, using numpy-style basic indexing.
-    #[pyo3(signature = (selection, /))]
+    #[pyo3(signature = (selection, /, **codec_options))]
     fn retrieve_array_subset<'py>(
         &self,
         py: Python<'py>,
         selection: PySelection,
+        codec_options: Option<PyCodecOptions>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
         let array_subset = self.array_subset(&selection)?;
+        let codec_options = codec_options
+            .map(|opts| opts.into_inner())
+            .unwrap_or_default();
 
         future_into_py(py, async move {
             let decoded = inner
-                .async_retrieve_array_subset::<PyTensor>(&array_subset)
+                .async_retrieve_array_subset_opt::<PyTensor>(&array_subset, &codec_options)
                 .await
                 .map_err(ZarristaError::from)?;
             Ok(decoded)

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -109,7 +109,7 @@ impl PyAsyncArray {
         })
     }
 
-    #[pyo3(signature = (chunk_indices, **codec_options))]
+    #[pyo3(signature = (chunk_indices, /, **codec_options))]
     fn compact_chunk<'py>(
         &self,
         py: Python<'py>,
@@ -185,6 +185,7 @@ impl PyAsyncArray {
     }
 
     /// Read a region of the array as `Data`, using numpy-style basic indexing.
+    #[pyo3(signature = (selection, /))]
     fn retrieve_array_subset<'py>(
         &self,
         py: Python<'py>,
@@ -202,7 +203,7 @@ impl PyAsyncArray {
         })
     }
 
-    #[pyo3(signature = (chunk_indices, **codec_options))]
+    #[pyo3(signature = (chunk_indices, /, **codec_options))]
     fn retrieve_chunk<'py>(
         &self,
         py: Python<'py>,
@@ -250,7 +251,7 @@ impl PyAsyncArray {
         })
     }
 
-    #[pyo3(signature = (subchunk_indices, *, shard_cache = None))]
+    #[pyo3(signature = (subchunk_indices, /, *, shard_cache = None))]
     fn retrieve_encoded_subchunk<'py>(
         &self,
         py: Python<'py>,
@@ -287,7 +288,7 @@ impl PyAsyncArray {
         })
     }
 
-    #[pyo3(signature = (subchunk_indices, *, shard_cache = None, **codec_options))]
+    #[pyo3(signature = (subchunk_indices, /, *, shard_cache = None, **codec_options))]
     fn retrieve_subchunk<'py>(
         &self,
         py: Python<'py>,
@@ -319,7 +320,7 @@ impl PyAsyncArray {
         self.store.clone()
     }
 
-    #[pyo3(signature = (selection, data, **codec_options))]
+    #[pyo3(signature = (selection, data, /, **codec_options))]
     fn store_array_subset<'py>(
         &self,
         py: Python<'py>,
@@ -346,7 +347,7 @@ impl PyAsyncArray {
         })
     }
 
-    #[pyo3(signature = (chunk_indices, decoded_chunk, **codec_options))]
+    #[pyo3(signature = (chunk_indices, decoded_chunk, /, **codec_options))]
     fn store_chunk<'py>(
         &self,
         py: Python<'py>,
@@ -372,7 +373,7 @@ impl PyAsyncArray {
         })
     }
 
-    #[pyo3(signature = (chunks, data, **codec_options))]
+    #[pyo3(signature = (chunks, data, /, **codec_options))]
     fn store_chunks<'py>(
         &self,
         py: Python<'py>,
@@ -404,6 +405,7 @@ impl PyAsyncArray {
         })
     }
 
+    #[pyo3(signature = (chunk_indices, encoded_chunk, /))]
     fn store_encoded_chunk<'py>(
         &self,
         py: Python<'py>,

--- a/src/array/async.rs
+++ b/src/array/async.rs
@@ -130,6 +130,7 @@ impl PyAsyncArray {
         })
     }
 
+    #[pyo3(signature = (chunk_indices, /))]
     fn erase_chunk<'py>(
         &self,
         py: Python<'py>,
@@ -145,6 +146,7 @@ impl PyAsyncArray {
         })
     }
 
+    #[pyo3(signature = (chunks, /))]
     fn erase_chunks<'py>(
         &self,
         py: Python<'py>,
@@ -221,6 +223,7 @@ impl PyAsyncArray {
         })
     }
 
+    #[pyo3(signature = (chunk_indices, /))]
     fn retrieve_encoded_chunk<'py>(
         &self,
         py: Python<'py>,

--- a/src/array/builder.rs
+++ b/src/array/builder.rs
@@ -35,6 +35,7 @@ impl PyArrayBuilder {
     }
 
     #[staticmethod]
+    #[pyo3(signature = (array, /))]
     fn like<'py>(array: Bound<'py, PyAny>) -> ZarristaResult<Self> {
         if let Ok(array) = array.cast::<PyArray>() {
             Ok(Self(ArrayBuilder::from_array(array.get().inner())))
@@ -52,18 +53,21 @@ impl PyArrayBuilder {
         }
     }
 
+    #[pyo3(signature = (attrs, /))]
     fn attrs(&self, attrs: PyAttributes) -> PyResult<Self> {
         Ok(self.with(|builder| {
             builder.attributes(attrs.into_inner());
         }))
     }
 
+    #[pyo3(signature = (chunk_grid, /))]
     fn chunk_grid(&self, chunk_grid: PyChunkGrid) -> Self {
         self.with(|builder| {
             builder.chunk_grid(chunk_grid.into_inner());
         })
     }
 
+    #[pyo3(signature = (chunk_key_encoding, /))]
     fn chunk_key_encoding(&self, chunk_key_encoding: PyChunkKeyEncoding) -> Self {
         self.with(|builder| {
             builder.chunk_key_encoding(chunk_key_encoding.into_inner());
@@ -73,6 +77,7 @@ impl PyArrayBuilder {
     // TODO:
     // fn codec_options
 
+    #[pyo3(signature = (compressors, /))]
     fn compressors(&self, compressors: Vec<PyBytesToBytesCodec>) -> Self {
         self.with(|builder| {
             builder
@@ -129,24 +134,28 @@ impl PyArrayBuilder {
     }
 
     /// Set the data type of the array to be built.
+    #[pyo3(signature = (data_type, /))]
     fn data_type(&self, data_type: PyDataType) -> Self {
         self.with(|builder| {
             builder.data_type(data_type.into_inner());
         })
     }
 
+    #[pyo3(signature = (dimension_names, /))]
     fn dimension_names(&self, dimension_names: Option<Vec<PyDimensionName>>) -> Self {
         self.with(|builder| {
             builder.dimension_names(dimension_names);
         })
     }
 
+    #[pyo3(signature = (filters, /))]
     fn filters(&self, filters: Vec<PyArrayToArrayCodec>) -> Self {
         self.with(|builder| {
             builder.array_to_array_codecs(filters.into_iter().map(|f| f.into_inner()).collect());
         })
     }
 
+    #[pyo3(signature = (serializer, /))]
     fn serializer(&self, serializer: PyArrayToBytesCodec) -> Self {
         self.with(|builder| {
             builder.array_to_bytes_codec(serializer.into_inner());
@@ -154,12 +163,14 @@ impl PyArrayBuilder {
     }
 
     /// Set the shape of the array to be built.
+    #[pyo3(signature = (shape, /))]
     fn shape(&self, shape: PyArrayShape) -> Self {
         self.with(|builder| {
             builder.shape(shape);
         })
     }
 
+    #[pyo3(signature = (subchunk_shape, /))]
     fn subchunk_shape(&self, subchunk_shape: Option<PyArrayShape>) -> Self {
         self.with(|builder| {
             builder.subchunk_shape(subchunk_shape);

--- a/src/array/chunk_grid.rs
+++ b/src/array/chunk_grid.rs
@@ -33,6 +33,7 @@ impl PyChunkGrid {
 #[pymethods]
 impl PyChunkGrid {
     #[staticmethod]
+    #[pyo3(signature = (array_shape, *, chunk_shapes))]
     fn rectilinear(
         array_shape: PyArrayShape,
         chunk_shapes: Vec<PyChunkEdgeLengths>,
@@ -43,6 +44,7 @@ impl PyChunkGrid {
     }
 
     #[staticmethod]
+    #[pyo3(signature = (array_shape, *, chunk_shape))]
     fn regular(array_shape: PyArrayShape, chunk_shape: PyChunkShape) -> ZarristaResult<Self> {
         let chunk_grid = RegularChunkGrid::new(array_shape, chunk_shape)?;
         Ok(Self(Arc::new(chunk_grid).into()))
@@ -50,6 +52,7 @@ impl PyChunkGrid {
 
     /// This chunk grid is experimental and may be incompatible with other Zarr V3 implementations.
     #[staticmethod]
+    #[pyo3(signature = (array_shape, *, chunk_shape))]
     fn regular_bounded(
         array_shape: PyArrayShape,
         chunk_shape: PyChunkShape,

--- a/src/array/chunk_key_encoding.rs
+++ b/src/array/chunk_key_encoding.rs
@@ -47,6 +47,7 @@ impl PyChunkKeyEncoding {
     }
 
     #[staticmethod]
+    #[pyo3(signature = (metadata, /))]
     fn from_metadata(metadata: PyMetadataV3) -> ZarristaResult<Self> {
         Ok(Self::new(ChunkKeyEncoding::from_metadata(
             metadata.as_ref(),

--- a/src/array/fill_value.rs
+++ b/src/array/fill_value.rs
@@ -39,6 +39,7 @@ impl PyFillValue {
         Ok(format!("FillValue({bytes})"))
     }
 
+    #[pyo3(signature = (other, /))]
     fn equals_all(&self, other: PyBytes) -> bool {
         self.0.equals_all(other.as_ref())
     }

--- a/src/array/shared.rs
+++ b/src/array/shared.rs
@@ -23,6 +23,7 @@ macro_rules! shared_array_methods {
                 self.inner.chunk_grid_shape()
             }
 
+            #[pyo3(signature = (chunk_indices, /))]
             fn chunk_key(
                 &self,
                 chunk_indices: $crate::array::PyChunkIndices,
@@ -35,6 +36,7 @@ macro_rules! shared_array_methods {
                 self.inner.chunk_key_encoding().clone().into()
             }
 
+            #[pyo3(signature = (chunk_indices, /))]
             fn chunk_origin(
                 &self,
                 chunk_indices: $crate::array::PyChunkIndices,
@@ -42,6 +44,7 @@ macro_rules! shared_array_methods {
                 Ok(self.inner.chunk_origin(chunk_indices.as_ref())?.into())
             }
 
+            #[pyo3(signature = (chunk_indices, /))]
             fn chunk_shape(
                 &self,
                 chunk_indices: $crate::array::PyChunkIndices,
@@ -49,6 +52,7 @@ macro_rules! shared_array_methods {
                 Ok(self.inner.chunk_shape(chunk_indices.as_ref())?.into())
             }
 
+            #[pyo3(signature = (chunk_indices, /))]
             fn chunk_subset(
                 &self,
                 chunk_indices: $crate::array::PyChunkIndices,
@@ -142,6 +146,7 @@ macro_rules! shared_array_methods {
             }
 
             /// Return a new array reference with `attrs`, leaving this one unchanged.
+            #[pyo3(signature = (attrs, /))]
             fn with_attrs(&self, attrs: $crate::metadata::PyAttributes) -> Self {
                 // Workaround for missing Clone
                 let mut updated = self.inner.with_storage(self.inner.storage());
@@ -150,6 +155,7 @@ macro_rules! shared_array_methods {
             }
 
             /// Return a new array reference with `chunk_grid`, leaving this one unchanged.
+            #[pyo3(signature = (chunk_grid, /))]
             fn with_chunk_grid(
                 &self,
                 chunk_grid: $crate::array::PyChunkGrid,
@@ -176,6 +182,7 @@ macro_rules! shared_array_methods {
             }
 
             /// Return a new array reference with `shape`, leaving this one unchanged.
+            #[pyo3(signature = (shape, /))]
             fn with_shape(
                 &self,
                 shape: $crate::array::PyArrayShape,

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -61,7 +61,7 @@ shared_array_methods!(PyArray);
 impl PyArray {
     /// Read a region with numpy-style basic indexing, e.g. `arr[0:10, :, 5]`.
     fn __getitem__(&self, py: Python, selection: PySelection) -> ZarristaResult<PyTensor> {
-        self.retrieve_array_subset(py, selection)
+        self.retrieve_array_subset(py, selection, None)
     }
 
     fn __repr__(&self, py: Python) -> PyResult<String> {
@@ -150,15 +150,21 @@ impl PyArray {
     /// Returns one of the decoded result classes (`FixedLengthTensor`,
     /// `VariableLengthTensor`, `OptionalFixedLengthTensor`,
     /// `OptionalVariableLengthTensor`) depending on the dtype layout.
-    #[pyo3(signature = (selection, /))]
+    #[pyo3(signature = (selection, /, **codec_options))]
     fn retrieve_array_subset(
         &self,
         py: Python,
         selection: PySelection,
+        codec_options: Option<PyCodecOptions>,
     ) -> ZarristaResult<PyTensor> {
         crate::py::detach(py, move || {
             let array_subset = self.array_subset(&selection)?;
-            Ok(self.inner.retrieve_array_subset(&array_subset)?)
+            let codec_options = codec_options
+                .map(|opts| opts.into_inner())
+                .unwrap_or_default();
+            Ok(self
+                .inner
+                .retrieve_array_subset_opt(&array_subset, &codec_options)?)
         })
     }
 

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -97,7 +97,7 @@ impl PyArray {
         Ok(Self::new(Arc::new(inner), store))
     }
 
-    #[pyo3(signature = (chunk_indices, **codec_options))]
+    #[pyo3(signature = (chunk_indices, /, **codec_options))]
     fn compact_chunk(
         &self,
         py: Python,
@@ -150,6 +150,7 @@ impl PyArray {
     /// Returns one of the decoded result classes (`FixedLengthTensor`,
     /// `VariableLengthTensor`, `OptionalFixedLengthTensor`,
     /// `OptionalVariableLengthTensor`) depending on the dtype layout.
+    #[pyo3(signature = (selection, /))]
     fn retrieve_array_subset(
         &self,
         py: Python,
@@ -161,7 +162,7 @@ impl PyArray {
         })
     }
 
-    #[pyo3(signature = (chunk_indices, **codec_options))]
+    #[pyo3(signature = (chunk_indices, /, **codec_options))]
     fn retrieve_chunk(
         &self,
         py: Python,
@@ -199,7 +200,7 @@ impl PyArray {
         })
     }
 
-    #[pyo3(signature = (subchunk_indices, *, shard_cache = None))]
+    #[pyo3(signature = (subchunk_indices, /, *, shard_cache = None))]
     fn retrieve_encoded_subchunk(
         &self,
         py: Python,
@@ -234,7 +235,7 @@ impl PyArray {
         })
     }
 
-    #[pyo3(signature = (subchunk_indices, *, shard_cache = None, **codec_options))]
+    #[pyo3(signature = (subchunk_indices, /, *, shard_cache = None, **codec_options))]
     fn retrieve_subchunk(
         &self,
         py: Python,
@@ -261,7 +262,7 @@ impl PyArray {
         self.store.clone()
     }
 
-    #[pyo3(signature = (selection, data, **codec_options))]
+    #[pyo3(signature = (selection, data, /, **codec_options))]
     fn store_array_subset(
         &self,
         py: Python,
@@ -281,7 +282,7 @@ impl PyArray {
         })
     }
 
-    #[pyo3(signature = (chunk_indices, decoded_chunk, **codec_options))]
+    #[pyo3(signature = (chunk_indices, decoded_chunk, /, **codec_options))]
     fn store_chunk(
         &self,
         py: Python,
@@ -302,7 +303,7 @@ impl PyArray {
         })
     }
 
-    #[pyo3(signature = (chunks, data, **codec_options))]
+    #[pyo3(signature = (chunks, data, /, **codec_options))]
     fn store_chunks(
         &self,
         py: Python,
@@ -325,6 +326,7 @@ impl PyArray {
         })
     }
 
+    #[pyo3(signature = (chunk_indices, encoded_chunk, /))]
     fn store_encoded_chunk(
         &self,
         py: Python,

--- a/src/array/sync.rs
+++ b/src/array/sync.rs
@@ -112,6 +112,7 @@ impl PyArray {
         })
     }
 
+    #[pyo3(signature = (chunk_indices, /))]
     fn erase_chunk(&self, py: Python, chunk_indices: PyChunkIndices) -> ZarristaResult<()> {
         crate::py::detach(py, || {
             self.inner.erase_chunk(&chunk_indices)?;
@@ -119,6 +120,7 @@ impl PyArray {
         })
     }
 
+    #[pyo3(signature = (chunks, /))]
     fn erase_chunks(&self, py: Python, chunks: PySelection) -> ZarristaResult<()> {
         crate::py::detach(py, move || {
             let chunks = self.chunk_grid_subset(&chunks)?;
@@ -176,6 +178,7 @@ impl PyArray {
         })
     }
 
+    #[pyo3(signature = (chunk_indices, /))]
     fn retrieve_encoded_chunk(
         &self,
         py: Python,

--- a/src/array_bytes.rs
+++ b/src/array_bytes.rs
@@ -22,11 +22,14 @@ pub struct PyArrayBytes(ArrayBytesOwned);
 #[pymethods]
 impl PyArrayBytes {
     #[new]
-    #[pyo3(signature = (bytes, *, mask=None, offsets=None))]
-    fn py_new(bytes: PyBytes, mask: Option<PyBytes>, offsets: Option<Vec<usize>>) -> Self {
+    #[pyo3(signature = (value, /, *, mask=None, offsets=None))]
+    fn py_new(value: PyBytes, mask: Option<PyBytes>, offsets: Option<Vec<usize>>) -> Self {
         let data = match offsets {
-            Some(offsets) => ArrayBytesOwned::Variable { bytes, offsets },
-            None => ArrayBytesOwned::Fixed(bytes),
+            Some(offsets) => ArrayBytesOwned::Variable {
+                bytes: value,
+                offsets,
+            },
+            None => ArrayBytesOwned::Fixed(value),
         };
         let repr = match mask {
             Some(mask) => ArrayBytesOwned::Optional {

--- a/src/codec/array_to_array.rs
+++ b/src/codec/array_to_array.rs
@@ -90,17 +90,18 @@ impl PyArrayToArrayCodec {
             .into())
     }
 
+    #[pyo3(signature = (value, /, shape, data_type, fill_value))]
     fn encode(
         &self,
         py: Python,
-        bytes: &PyArrayBytes,
+        value: &PyArrayBytes,
         shape: Vec<NonZeroU64>,
         data_type: &PyDataType,
         fill_value: &PyFillValue,
     ) -> ZarristaResult<PyArrayBytes> {
         crate::py::detach(py, || {
             let encoded = self.0.encode(
-                bytes.as_array_bytes()?,
+                value.as_array_bytes()?,
                 &shape,
                 data_type.inner(),
                 fill_value.inner(),
@@ -110,17 +111,18 @@ impl PyArrayToArrayCodec {
         })
     }
 
+    #[pyo3(signature = (value, /, shape, data_type, fill_value))]
     fn decode(
         &self,
         py: Python,
-        bytes: &PyArrayBytes,
+        value: &PyArrayBytes,
         shape: Vec<NonZeroU64>,
         data_type: &PyDataType,
         fill_value: &PyFillValue,
     ) -> ZarristaResult<PyArrayBytes> {
         crate::py::detach(py, || {
             let decoded = self.0.decode(
-                bytes.as_array_bytes()?,
+                value.as_array_bytes()?,
                 &shape,
                 data_type.inner(),
                 fill_value.inner(),

--- a/src/codec/array_to_array.rs
+++ b/src/codec/array_to_array.rs
@@ -56,6 +56,7 @@ impl PyArrayToArrayCodec {
 
     /// Build a codec from its Zarr v3 metadata,
     #[staticmethod]
+    #[pyo3(signature = (metadata, /))]
     fn from_config(metadata: PyMetadataV3) -> ZarristaResult<Self> {
         let codec = Codec::from_metadata(CodecMetadata::V3(metadata.as_ref()))?;
         match codec {

--- a/src/codec/array_to_bytes/mod.rs
+++ b/src/codec/array_to_bytes/mod.rs
@@ -46,6 +46,7 @@ impl PyArrayToBytesCodec {
 
     /// Build a codec from its Zarr v3 metadata,
     #[staticmethod]
+    #[pyo3(signature = (metadata, /))]
     fn from_config(metadata: PyMetadataV3) -> ZarristaResult<Self> {
         let codec = Codec::from_metadata(CodecMetadata::V3(metadata.as_ref()))?;
         match codec {

--- a/src/codec/bytes_to_bytes/mod.rs
+++ b/src/codec/bytes_to_bytes/mod.rs
@@ -47,6 +47,7 @@ impl PyBytesToBytesCodec {
 
     /// Build a codec from its Zarr v3 metadata,
     #[staticmethod]
+    #[pyo3(signature = (metadata, /))]
     fn from_config(metadata: PyMetadataV3) -> ZarristaResult<Self> {
         let codec = Codec::from_metadata(CodecMetadata::V3(metadata.as_ref()))?;
         match codec {
@@ -65,6 +66,7 @@ impl PyBytesToBytesCodec {
             .map(|config| config.into())
     }
 
+    #[pyo3(signature = (decoded_value, /))]
     fn encode(&self, py: Python, decoded_value: PyBytes) -> ZarristaResult<PyBytes> {
         crate::py::detach(py, || {
             let encoded = self.0.encode(

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -32,6 +32,7 @@ impl PyDataType {
 impl PyDataType {
     /// Construct a data type from its Zarr v3 metadata.
     #[staticmethod]
+    #[pyo3(signature = (metadata, /))]
     fn from_metadata(metadata: PyMetadataV3) -> ZarristaResult<Self> {
         let data_type = DataType::from_metadata(&metadata.into_inner())?;
         Ok(Self { inner: data_type })
@@ -39,6 +40,7 @@ impl PyDataType {
 
     /// Construct a data type from its Zarr v3 name (e.g. `"float32"`).
     #[staticmethod]
+    #[pyo3(signature = (name, /))]
     fn from_string(name: &str) -> ZarristaResult<Self> {
         let metadata = MetadataV3::new(name);
         let data_type = DataType::from_metadata(&metadata)?;

--- a/src/group/async.rs
+++ b/src/group/async.rs
@@ -87,6 +87,7 @@ impl PyAsyncGroup {
     }
 
     /// Open a direct child array or group by name.
+    #[pyo3(signature = (name, /))]
     fn child<'py>(&self, py: Python<'py>, name: String) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
         let storage = self.store.clone();

--- a/src/group/shared.rs
+++ b/src/group/shared.rs
@@ -34,6 +34,7 @@ macro_rules! group_metadata_accessors {
             }
 
             /// Return a new group reference with `attrs`, leaving this one unchanged.
+            #[pyo3(signature = (attrs, /))]
             fn with_attrs(
                 &self,
                 attrs: $crate::metadata::PyAttributes,
@@ -55,6 +56,7 @@ macro_rules! group_metadata_accessors {
             }
 
             /// Return a new group reference with `consolidated_metadata`, leaving this one unchanged.
+            #[pyo3(signature = (consolidated_metadata, /))]
             fn with_consolidated_metadata(
                 &self,
                 consolidated_metadata: Option<$crate::metadata::PyConsolidatedMetadata>,

--- a/src/group/sync.rs
+++ b/src/group/sync.rs
@@ -78,6 +78,7 @@ impl PyGroup {
         self.child(py, name)
     }
 
+    #[pyo3(signature = (name, /))]
     fn child(&self, py: Python, name: PyBackedStr) -> ZarristaResult<PyNode> {
         crate::py::detach(py, || {
             let children = self.inner.children(false)?;

--- a/tests/array/test_encoded_chunk.py
+++ b/tests/array/test_encoded_chunk.py
@@ -32,7 +32,7 @@ DATA = np.arange(16, dtype="int32").reshape(4, 4)
 def _array(*, compressed: bool = False) -> Array:
     """A 4x4 int32 array in one 4x4 chunk."""
     builder = ArrayBuilder(
-        ChunkGrid.regular([4, 4], [4, 4]),
+        ChunkGrid.regular([4, 4], chunk_shape=[4, 4]),
         DataType.from_string("int32"),
         FillValue(b"\x00\x00\x00\x00"),
     )
@@ -157,7 +157,7 @@ async def test_async_array_returns_an_encoded_chunk(tmp_path: Path):
     """`AsyncArray.retrieve_encoded_chunk` mirrors the sync method."""
     arr = await (
         ArrayBuilder(
-            ChunkGrid.regular([4, 4], [4, 4]),
+            ChunkGrid.regular([4, 4], chunk_shape=[4, 4]),
             DataType.from_string("int32"),
             FillValue(b"\x00\x00\x00\x00"),
         )
@@ -175,7 +175,7 @@ async def test_async_array_returns_an_encoded_chunk(tmp_path: Path):
 
 async def test_async_array_absent_chunk_is_none(tmp_path: Path):
     arr = await ArrayBuilder(
-        ChunkGrid.regular([4, 4], [4, 4]),
+        ChunkGrid.regular([4, 4], chunk_shape=[4, 4]),
         DataType.from_string("int32"),
         FillValue(b"\x00\x00\x00\x00"),
     ).create_async(LocalStore(str(tmp_path)), "/a")

--- a/tests/array/test_erase.py
+++ b/tests/array/test_erase.py
@@ -41,7 +41,7 @@ EMPTY = np.zeros((4, 4), dtype="int32")
 def _chunked_array() -> Array:
     """A 4x4 int32 array: a 2x2 grid of 2x2 chunks, each filled with `1 + 2i + j`."""
     array = ArrayBuilder(
-        ChunkGrid.regular([4, 4], [2, 2]),
+        ChunkGrid.regular([4, 4], chunk_shape=[2, 2]),
         DataType.from_string("int32"),
         FillValue(b"\x00\x00\x00\x00"),
     ).create(MemoryStore(), "/a")
@@ -56,7 +56,7 @@ def _sharded_array() -> Array:
     """An 8x8 int32 array: a 2x2 grid of 4x4 shards, each split into 2x2 subchunks."""
     array = (
         ArrayBuilder(
-            ChunkGrid.regular([8, 8], [4, 4]),
+            ChunkGrid.regular([8, 8], chunk_shape=[4, 4]),
             DataType.from_string("int32"),
             FillValue(b"\x00\x00\x00\x00"),
         )

--- a/tests/array/test_read_only.py
+++ b/tests/array/test_read_only.py
@@ -11,7 +11,7 @@ from zarrista.store import MemoryStore
 def _writable_array() -> Array:
     """A 4x4 int8 array (single 4x4 chunk, fill 0) created in a MemoryStore."""
     return ArrayBuilder(
-        ChunkGrid.regular([4, 4], [4, 4]),
+        ChunkGrid.regular([4, 4], chunk_shape=[4, 4]),
         DataType.from_string("int8"),
         FillValue(b"\x00"),
     ).create(MemoryStore(), "/a")

--- a/tests/array/test_shard_cache.py
+++ b/tests/array/test_shard_cache.py
@@ -33,7 +33,7 @@ def _builder() -> ArrayBuilder:
     subchunk rows 2 and 3 live in shard [1, 0].
     """
     return ArrayBuilder(
-        ChunkGrid.regular([8, 4], [4, 4]),
+        ChunkGrid.regular([8, 4], chunk_shape=[4, 4]),
         DataType.from_string("int32"),
         FillValue(b"\x00\x00\x00\x00"),
     ).subchunk_shape([2, 2])

--- a/tests/array/test_store_chunks.py
+++ b/tests/array/test_store_chunks.py
@@ -19,7 +19,7 @@ DATA = np.arange(16, dtype="int32").reshape(4, 4)
 def _array() -> Array:
     """A 4x4 int32 array chunked 2x2, so the chunk grid is 2x2."""
     return ArrayBuilder(
-        ChunkGrid.regular([4, 4], [2, 2]),
+        ChunkGrid.regular([4, 4], chunk_shape=[2, 2]),
         DataType.from_string("int32"),
         FillValue(b"\x00\x00\x00\x00"),
     ).create(MemoryStore(), "/a")
@@ -52,7 +52,7 @@ def test_partial_selection_spans_the_remaining_dimensions() -> None:
     the first dimension. Those span 2x4x4 elements, not the 2x2x2 of one chunk.
     """
     array = ArrayBuilder(
-        ChunkGrid.regular([4, 4, 4], [2, 2, 2]),
+        ChunkGrid.regular([4, 4, 4], chunk_shape=[2, 2, 2]),
         DataType.from_string("int32"),
         FillValue(b"\x00\x00\x00\x00"),
     ).create(MemoryStore(), "/a")
@@ -75,7 +75,7 @@ def test_data_shaped_like_the_chunk_grid_raises() -> None:
 async def test_async_writes_a_single_chunk_into_its_element_region(tmp_path) -> None:
     store = LocalStore(str(tmp_path))
     array = await ArrayBuilder(
-        ChunkGrid.regular([4, 4], [2, 2]),
+        ChunkGrid.regular([4, 4], chunk_shape=[2, 2]),
         DataType.from_string("int32"),
         FillValue(b"\x00\x00\x00\x00"),
     ).create_async(store, "/a")

--- a/tests/array/test_subchunk.py
+++ b/tests/array/test_subchunk.py
@@ -33,7 +33,7 @@ DATA = np.arange(16, dtype="int32").reshape(4, 4)
 def _builder(*, compressed: bool = False) -> ArrayBuilder:
     """A 4x4 int32 array: one 4x4 shard split into 2x2 subchunks (a 2x2 grid)."""
     builder = ArrayBuilder(
-        ChunkGrid.regular([4, 4], [4, 4]),
+        ChunkGrid.regular([4, 4], chunk_shape=[4, 4]),
         DataType.from_string("int32"),
         FillValue(b"\x00\x00\x00\x00"),
     ).subchunk_shape([2, 2])

--- a/tests/array/test_with_attrs.py
+++ b/tests/array/test_with_attrs.py
@@ -10,7 +10,7 @@ from zarrista.store import MemoryStore
 def _builder() -> ArrayBuilder:
     """A 4x4 int8 array, chunked 2x2, fill 0, with two user attributes."""
     return ArrayBuilder(
-        ChunkGrid.regular([4, 4], [2, 2]),
+        ChunkGrid.regular([4, 4], chunk_shape=[2, 2]),
         DataType.from_string("int8"),
         FillValue(b"\x00"),
     ).attrs({"units": "m", "long_name": "height"})

--- a/tests/array/test_with_chunk_grid.py
+++ b/tests/array/test_with_chunk_grid.py
@@ -23,7 +23,7 @@ def _array(store: MemoryStore) -> Array:
     `ArrayBuilder.create` writes the metadata, so the array is openable.
     """
     return ArrayBuilder(
-        ChunkGrid.regular([4, 4], [2, 2]),
+        ChunkGrid.regular([4, 4], chunk_shape=[2, 2]),
         DataType.from_string("int8"),
         FillValue(b"\x00"),
     ).create(store, "/a")
@@ -32,45 +32,61 @@ def _array(store: MemoryStore) -> Array:
 def test_returns_new_array_and_leaves_original() -> None:
     array = _array(MemoryStore())
 
-    regridded = array.with_chunk_grid(ChunkGrid.regular([8, 8], [4, 4]))
+    regridded = array.with_chunk_grid(ChunkGrid.regular([8, 8], chunk_shape=[4, 4]))
 
     assert regridded.shape == [8, 8]
-    assert regridded.chunk_grid.metadata == ChunkGrid.regular([8, 8], [4, 4]).metadata
+    assert (
+        regridded.chunk_grid.metadata
+        == ChunkGrid.regular([8, 8], chunk_shape=[4, 4]).metadata
+    )
     assert array.shape == [4, 4]
-    assert array.chunk_grid.metadata == ChunkGrid.regular([4, 4], [2, 2]).metadata
+    assert (
+        array.chunk_grid.metadata
+        == ChunkGrid.regular([4, 4], chunk_shape=[2, 2]).metadata
+    )
 
 
 def test_does_not_write() -> None:
     store = MemoryStore()
     array = _array(store)
 
-    array.with_chunk_grid(ChunkGrid.regular([8, 8], [4, 4]))
+    array.with_chunk_grid(ChunkGrid.regular([8, 8], chunk_shape=[4, 4]))
 
     # The stored metadata is untouched until `store_metadata` is called.
     reopened = Array.open(store, "/a")
     assert reopened.shape == [4, 4]
-    assert reopened.chunk_grid.metadata == ChunkGrid.regular([4, 4], [2, 2]).metadata
+    assert (
+        reopened.chunk_grid.metadata
+        == ChunkGrid.regular([4, 4], chunk_shape=[2, 2]).metadata
+    )
 
 
 def test_chunk_shape_change_persists() -> None:
     store = MemoryStore()
-    _array(store).with_chunk_grid(ChunkGrid.regular([4, 4], [4, 4])).store_metadata()
+    _array(store).with_chunk_grid(
+        ChunkGrid.regular([4, 4], chunk_shape=[4, 4]),
+    ).store_metadata()
 
     reopened = Array.open(store, "/a")
     assert reopened.shape == [4, 4]
-    assert reopened.chunk_grid.metadata == ChunkGrid.regular([4, 4], [4, 4]).metadata
+    assert (
+        reopened.chunk_grid.metadata
+        == ChunkGrid.regular([4, 4], chunk_shape=[4, 4]).metadata
+    )
 
 
 def test_shape_may_change_too() -> None:
     store = MemoryStore()
-    _array(store).with_chunk_grid(ChunkGrid.regular([8, 8], [2, 2])).store_metadata()
+    _array(store).with_chunk_grid(
+        ChunkGrid.regular([8, 8], chunk_shape=[2, 2]),
+    ).store_metadata()
 
     assert Array.open(store, "/a").shape == [8, 8]
 
 
 def test_rectilinear_grid_accepted() -> None:
     array = _array(MemoryStore())
-    grid = ChunkGrid.rectilinear([4, 4], [2, 2])
+    grid = ChunkGrid.rectilinear([4, 4], chunk_shapes=[2, 2])
 
     regridded = array.with_chunk_grid(grid)
 
@@ -87,7 +103,9 @@ def test_existing_chunks_are_not_migrated() -> None:
     array.store_chunk([0, 0], ArrayBytes(np.arange(4, dtype="int8").tobytes()))
 
     # A 4x4 chunk would be 16 bytes.
-    array.with_chunk_grid(ChunkGrid.regular([4, 4], [4, 4])).store_metadata()
+    array.with_chunk_grid(
+        ChunkGrid.regular([4, 4], chunk_shape=[4, 4]),
+    ).store_metadata()
 
     # `array` still describes the 2x2 grid, so it can still address the old chunk.
     # It is untouched: still 4 bytes, not re-encoded to 16.
@@ -99,15 +117,21 @@ def test_existing_chunks_are_not_migrated() -> None:
 
 async def test_async_with_chunk_grid(tmp_path: Path) -> None:
     array = await ArrayBuilder(
-        ChunkGrid.regular([4, 4], [2, 2]),
+        ChunkGrid.regular([4, 4], chunk_shape=[2, 2]),
         DataType.from_string("int8"),
         FillValue(b"\x00"),
     ).create_async(LocalStore(str(tmp_path)), "/a")
 
     # `with_chunk_grid` is sync even on `AsyncArray`: it performs no I/O.
-    regridded = array.with_chunk_grid(ChunkGrid.regular([4, 4], [4, 4]))
+    regridded = array.with_chunk_grid(ChunkGrid.regular([4, 4], chunk_shape=[4, 4]))
     await regridded.store_metadata()
 
-    assert array.chunk_grid.metadata == ChunkGrid.regular([4, 4], [2, 2]).metadata
+    assert (
+        array.chunk_grid.metadata
+        == ChunkGrid.regular([4, 4], chunk_shape=[2, 2]).metadata
+    )
     reopened = await AsyncArray.open(LocalStore(str(tmp_path)), "/a")
-    assert reopened.chunk_grid.metadata == ChunkGrid.regular([4, 4], [4, 4]).metadata
+    assert (
+        reopened.chunk_grid.metadata
+        == ChunkGrid.regular([4, 4], chunk_shape=[4, 4]).metadata
+    )

--- a/tests/array/test_with_shape.py
+++ b/tests/array/test_with_shape.py
@@ -25,7 +25,7 @@ def _array(store: MemoryStore) -> Array:
     `ArrayBuilder.create` writes the metadata, so the array is openable.
     """
     return ArrayBuilder(
-        ChunkGrid.regular([4, 4], [2, 2]),
+        ChunkGrid.regular([4, 4], chunk_shape=[2, 2]),
         DataType.from_string("int8"),
         FillValue(b"\x00"),
     ).create(store, "/a")
@@ -101,7 +101,7 @@ def test_wrong_dimensionality_raises(shape: list[int]) -> None:
 
 async def test_async_with_shape_returns_new_array(tmp_path: Path) -> None:
     array = await ArrayBuilder(
-        ChunkGrid.regular([4, 4], [2, 2]),
+        ChunkGrid.regular([4, 4], chunk_shape=[2, 2]),
         DataType.from_string("int8"),
         FillValue(b"\x00"),
     ).create_async(LocalStore(str(tmp_path)), "/a")

--- a/tests/data/test_dlpack.py
+++ b/tests/data/test_dlpack.py
@@ -48,7 +48,7 @@ def _fill_value(dtype: str) -> FillValue:
 def _array(dtype: str = "int32", *, shape: list[int] | None = None) -> Array:
     shape = shape or [4, 4]
     return ArrayBuilder(
-        ChunkGrid.regular(shape, [2, 2]),
+        ChunkGrid.regular(shape, chunk_shape=[2, 2]),
         DataType.from_string(dtype),
         _fill_value(dtype),
     ).create(MemoryStore(), "/a")
@@ -232,7 +232,7 @@ async def test_async_write_outlives_the_source_array(tmp_path):
     """The async write moves the tensor into a `'static` future, and its
     deleter runs on whichever thread drops that future."""
     arr = await ArrayBuilder(
-        ChunkGrid.regular([4, 4], [2, 2]),
+        ChunkGrid.regular([4, 4], chunk_shape=[2, 2]),
         DataType.from_string("int32"),
         _fill_value("int32"),
     ).create_async(LocalStore(str(tmp_path)), "/a")
@@ -252,7 +252,7 @@ async def test_many_concurrent_async_writes(tmp_path):
     import asyncio
 
     arr = await ArrayBuilder(
-        ChunkGrid.regular([4, 4], [2, 2]),
+        ChunkGrid.regular([4, 4], chunk_shape=[2, 2]),
         DataType.from_string("int32"),
         _fill_value("int32"),
     ).create_async(LocalStore(str(tmp_path)), "/a")

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -19,7 +19,7 @@ from zarrista.store import MemoryStore
 def _builder() -> ArrayBuilder:
     """A minimal int8 builder: 8x8 array, 4x4 regular chunks, fill value 0."""
     return ArrayBuilder(
-        ChunkGrid.regular([8, 8], [4, 4]),
+        ChunkGrid.regular([8, 8], chunk_shape=[4, 4]),
         DataType.from_string("int8"),
         FillValue(b"\x00"),
     )
@@ -164,7 +164,7 @@ def test_like_with_override():
 def test_chunk_grid_dimension_mismatch_raises():
     """A chunk shape with the wrong dimensionality is rejected at parse time."""
     with pytest.raises(ChunkGridCreateError):
-        ChunkGrid.regular([8, 8], [4, 4, 4])
+        ChunkGrid.regular([8, 8], chunk_shape=[4, 4, 4])
 
 
 def test_chunk_grid_create_error_is_zarrista_error():

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -142,7 +142,7 @@ def test_store_repr_names_its_argument() -> None:
 
 def test_chunk_grid_repr() -> None:
     """Reuses the named-configuration form, so it reads like the codecs."""
-    grid = ChunkGrid.regular([4, 4], [2, 2])
+    grid = ChunkGrid.regular([4, 4], chunk_shape=[2, 2])
 
     assert repr(grid) == "ChunkGrid('regular', config={'chunk_shape': [2, 2]})"
 
@@ -163,7 +163,7 @@ def test_array_bytes_repr() -> None:
 
 def test_array_builder_repr() -> None:
     builder = ArrayBuilder(
-        ChunkGrid.regular([4, 4], [2, 2]),
+        ChunkGrid.regular([4, 4], chunk_shape=[2, 2]),
         DataType.from_string("int32"),
         FillValue(b"\x00\x00\x00\x00"),
     )


### PR DESCRIPTION
API review before 0.1 of API signatures and when args should be positional-only

### Change list

- Pass to apply positional-only parameters to many APIs
- New skill to do an API review before a release
- Change `ChunkGrid` to require `chunk_shape` as a named arg