### PR TITLE
perf: Opt-in to zlib-rs for gzip encode/decode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,6 +1616,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -5329,6 +5330,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "dlpark",
+ "flate2",
  "icechunk",
  "object_store 0.13.2",
  "pyo3",
@@ -5655,6 +5657,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ bytes = "1.12.0"
 dlpark = { git = "https://github.com/kylebarron/dlpark", rev = "f6887bf8b367d98d079710be9659c4177ba899f8", features = [
     "pyo3",
 ] }
+# Opt-in to flate2's zlib-rs backend
+flate2 = { version = "1.1", features = ["zlib-rs"] }
 icechunk = { version = "2.0.0", default-features = false, optional = true }
 object_store = { version = "0.13", optional = true }
 pyo3 = { version = "0.29", features = ["macros", "multiple-pymethods"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ mod storage;
 mod thread_pool;
 mod wasm;
 
+// In cargo.toml only to select the zlib-rs backend for zarrs' gzip/zlib codecs
+use flate2 as _;
 use pyo3::prelude::*;
 // In cargo.toml only to add decompression support to zarrs_zip
 use rc_zip as _;


### PR DESCRIPTION
We use cargo's feature unification to turn on flate2's zlib-rs backend